### PR TITLE
Bump lower bound on commonprotos to 1.3.5.

### DIFF
--- a/generated/python/gapic-google-cloud-language-v1beta1/setup.py
+++ b/generated/python/gapic-google-cloud-language-v1beta1/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>=1.3.4, <2.0.0dev',
+    'googleapis-common-protos>=1.3.5, <2.0.0dev',
     'google-gax>=0.14.1, <0.15.0dev',
     'grpc-google-cloud-language-v1beta1>=0.10.1, <0.11.0dev',
     'oauth2client>=3.0.0, <4.0.0dev',

--- a/generated/python/gapic-google-cloud-vision-v1/setup.py
+++ b/generated/python/gapic-google-cloud-vision-v1/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>=1.3.4, <2.0.0dev',
+    'googleapis-common-protos>=1.3.5, <2.0.0dev',
     'google-gax>=0.14.1, <0.15.0dev',
     'grpc-google-cloud-vision-v1>=0.10.1, <0.11.0dev',
     'oauth2client>=3.0.0, <4.0.0dev',

--- a/generated/python/gapic-google-logging-v2/setup.py
+++ b/generated/python/gapic-google-logging-v2/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>=1.3.4, <2.0.0dev',
+    'googleapis-common-protos>=1.3.5, <2.0.0dev',
     'google-gax>=0.14.1, <0.15.0dev',
     'grpc-google-logging-v2>=0.10.1, <0.11.0dev',
     'oauth2client>=3.0.0, <4.0.0dev',

--- a/generated/python/gapic-google-pubsub-v1/setup.py
+++ b/generated/python/gapic-google-pubsub-v1/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>=1.3.4, <2.0.0dev',
+    'googleapis-common-protos>=1.3.5, <2.0.0dev',
     'google-gax>=0.14.1, <0.15.0dev',
     'grpc-google-pubsub-v1>=0.10.1, <0.11.0dev',
     'grpc-google-iam-v1>=0.10.0, <0.11.0dev',

--- a/generated/python/grpc-google-cloud-language-v1beta1/setup.py
+++ b/generated/python/grpc-google-cloud-language-v1beta1/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=3.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0dev'
+  'googleapis-common-protos[grpc]>=1.3.5, <2.0.0dev'
 ]
 
 setuptools.setup(

--- a/generated/python/grpc-google-cloud-vision-v1/setup.py
+++ b/generated/python/grpc-google-cloud-vision-v1/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=3.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0dev'
+  'googleapis-common-protos[grpc]>=1.3.5, <2.0.0dev'
 ]
 
 setuptools.setup(

--- a/generated/python/grpc-google-iam-v1/setup.py
+++ b/generated/python/grpc-google-iam-v1/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=3.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0dev'
+  'googleapis-common-protos[grpc]>=1.3.5, <2.0.0dev'
 ]
 
 setuptools.setup(

--- a/generated/python/grpc-google-logging-v2/setup.py
+++ b/generated/python/grpc-google-logging-v2/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=3.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0dev'
+  'googleapis-common-protos[grpc]>=1.3.5, <2.0.0dev'
 ]
 
 setuptools.setup(

--- a/generated/python/grpc-google-pubsub-v1/setup.py
+++ b/generated/python/grpc-google-pubsub-v1/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=3.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0dev'
+  'googleapis-common-protos[grpc]>=1.3.5, <2.0.0dev'
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Mostly useful for logging, but being comprehensive.

See https://github.com/googleapis/api-client-staging/pull/50/files#diff-c534e11078a491e0fb0d0995ec8a76fcR1 for this new version of commonprotos.