### PR TITLE
Regenerate Go clients

### DIFF
--- a/generated/go/google-cloud-language-v1beta1/cloud.google.com/go/language/apiv1beta1/language_client.go
+++ b/generated/go/google-cloud-language-v1beta1/cloud.google.com/go/language/apiv1beta1/language_client.go
@@ -81,7 +81,7 @@ type Client struct {
 	CallOptions *CallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewClient creates a new language service client.
@@ -118,9 +118,8 @@ func (c *Client) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *Client) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // AnalyzeSentiment analyzes the sentiment of the provided text.

--- a/generated/go/google-cloud-speech-v1beta1/cloud.google.com/go/speech/apiv1beta1/speech_client_example_test.go
+++ b/generated/go/google-cloud-speech-v1beta1/cloud.google.com/go/speech/apiv1beta1/speech_client_example_test.go
@@ -17,6 +17,8 @@
 package speech_test
 
 import (
+	"io"
+
 	"cloud.google.com/go/speech/apiv1beta1"
 	"golang.org/x/net/context"
 	speechpb "google.golang.org/genproto/googleapis/cloud/speech/v1beta1"
@@ -66,4 +68,38 @@ func ExampleClient_AsyncRecognize() {
 	}
 	// TODO: Use resp.
 	_ = resp
+}
+
+func StreamingRecognize() {
+	ctx := context.Background()
+	c, err := speech.NewClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	stream, err := c.StreamingRecognize(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	go func() {
+		reqs := []*speechpb.StreamingRecognizeRequest{
+		// TODO: Create requests.
+		}
+		for _, req := range reqs {
+			if err := stream.Send(req); err != nil {
+				// TODO: Handle error.
+			}
+		}
+		stream.CloseSend()
+	}()
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// TODO: handle error.
+		}
+		// TODO: Use resp.
+		_ = resp
+	}
 }

--- a/generated/go/google-cloud-vision-v1/cloud.google.com/go/vision/apiv1/doc.go
+++ b/generated/go/google-cloud-vision-v1/cloud.google.com/go/vision/apiv1/doc.go
@@ -20,6 +20,8 @@
 // Integrates Google Vision features, including image labeling, face, logo,
 // and landmark detection, optical character recognition (OCR), and detection
 // of explicit content, into applications.
+//
+// Use the client at cloud.google.com/go/vision in preference to this.
 package vision // import "cloud.google.com/go/vision/apiv1"
 
 const gapicNameVersion = "gapic/0.1.0"

--- a/generated/go/google-cloud-vision-v1/cloud.google.com/go/vision/apiv1/image_annotator_client.go
+++ b/generated/go/google-cloud-vision-v1/cloud.google.com/go/vision/apiv1/image_annotator_client.go
@@ -77,7 +77,7 @@ type ImageAnnotatorClient struct {
 	CallOptions *ImageAnnotatorCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewImageAnnotatorClient creates a new image annotator client.
@@ -115,9 +115,8 @@ func (c *ImageAnnotatorClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *ImageAnnotatorClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // BatchAnnotateImages run image detection and annotation for a batch of images.

--- a/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/controller2_client.go
+++ b/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/controller2_client.go
@@ -82,7 +82,7 @@ type Controller2Client struct {
 	CallOptions *Controller2CallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewController2Client creates a new controller2 client.
@@ -137,9 +137,8 @@ func (c *Controller2Client) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *Controller2Client) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // RegisterDebuggee registers the debuggee with the controller service.

--- a/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/debugger2_client.go
+++ b/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/debugger2_client.go
@@ -86,7 +86,7 @@ type Debugger2Client struct {
 	CallOptions *Debugger2CallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewDebugger2Client creates a new debugger2 client.
@@ -133,9 +133,8 @@ func (c *Debugger2Client) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *Debugger2Client) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // SetBreakpoint sets the breakpoint to the debuggee.

--- a/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/doc.go
+++ b/generated/go/google-devtools-clouddebugger-v2/cloud.google.com/go/debugger/apiv2/doc.go
@@ -20,6 +20,8 @@
 // Examines the call stack and variables of a running application
 // without stopping or slowing it down.
 //
+//
+// Use the client at cloud.google.com/go/cmd/go-cloud-debug-agent in preference to this.
 package debugger // import "cloud.google.com/go/debugger/apiv2"
 
 const gapicNameVersion = "gapic/0.1.0"

--- a/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/error_group_client.go
+++ b/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/error_group_client.go
@@ -83,7 +83,7 @@ type ErrorGroupClient struct {
 	CallOptions *ErrorGroupCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewErrorGroupClient creates a new error group service client.
@@ -119,9 +119,8 @@ func (c *ErrorGroupClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *ErrorGroupClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // ErrorGroupGroupPath returns the path for the group resource.

--- a/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/error_stats_client.go
+++ b/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/error_stats_client.go
@@ -87,7 +87,7 @@ type ErrorStatsClient struct {
 	CallOptions *ErrorStatsCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewErrorStatsClient creates a new error stats service client.
@@ -124,9 +124,8 @@ func (c *ErrorStatsClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *ErrorStatsClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // ErrorStatsProjectPath returns the path for the project resource.

--- a/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/report_errors_client.go
+++ b/generated/go/google-devtools-clouderrorreporting-v1beta1/cloud.google.com/go/errorreporting/apiv1beta1/report_errors_client.go
@@ -66,7 +66,7 @@ type ReportErrorsClient struct {
 	CallOptions *ReportErrorsCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewReportErrorsClient creates a new report errors service client.
@@ -102,9 +102,8 @@ func (c *ReportErrorsClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *ReportErrorsClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // ReportErrorsProjectPath returns the path for the project resource.

--- a/generated/go/google-devtools-cloudtrace-v1/cloud.google.com/go/trace/apiv1/doc.go
+++ b/generated/go/google-devtools-cloudtrace-v1/cloud.google.com/go/trace/apiv1/doc.go
@@ -22,6 +22,8 @@
 // applications can be written to Stackdriver Trace for display, reporting,
 // and analysis.
 //
+//
+// Use the client at cloud.google.com/go/trace in preference to this.
 package trace // import "cloud.google.com/go/trace/apiv1"
 
 const gapicNameVersion = "gapic/0.1.0"

--- a/generated/go/google-devtools-cloudtrace-v1/cloud.google.com/go/trace/apiv1/trace_client.go
+++ b/generated/go/google-devtools-cloudtrace-v1/cloud.google.com/go/trace/apiv1/trace_client.go
@@ -85,7 +85,7 @@ type Client struct {
 	CallOptions *CallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewClient creates a new trace service client.
@@ -125,9 +125,8 @@ func (c *Client) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *Client) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // PatchTraces sends new traces to Stackdriver Trace or updates existing traces. If the ID

--- a/generated/go/google-iam-admin-v1/cloud.google.com/go/iam/admin/apiv1/iam_client_example_test.go
+++ b/generated/go/google-iam-admin-v1/cloud.google.com/go/iam/admin/apiv1/iam_client_example_test.go
@@ -20,7 +20,6 @@ import (
 	"cloud.google.com/go/iam/admin/apiv1"
 	"golang.org/x/net/context"
 	adminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 )
 
 func ExampleNewIamClient() {
@@ -206,60 +205,6 @@ func ExampleIamClient_SignBlob() {
 	// TODO: Fill request struct fields.
 	}
 	resp, err := c.SignBlob(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExampleIamClient_GetIamPolicy() {
-	ctx := context.Background()
-	c, err := admin.NewIamClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.GetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.GetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExampleIamClient_SetIamPolicy() {
-	ctx := context.Background()
-	c, err := admin.NewIamClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.SetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.SetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExampleIamClient_TestIamPermissions() {
-	ctx := context.Background()
-	c, err := admin.NewIamClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.TestIamPermissionsRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.TestIamPermissions(ctx, req)
 	if err != nil {
 		// TODO: Handle error.
 	}

--- a/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/config_client.go
+++ b/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/config_client.go
@@ -96,7 +96,7 @@ type ConfigClient struct {
 	CallOptions *ConfigCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewConfigClient creates a new config service v2 client.
@@ -133,9 +133,8 @@ func (c *ConfigClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *ConfigClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // ConfigParentPath returns the path for the parent resource.

--- a/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/doc.go
+++ b/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/doc.go
@@ -19,6 +19,8 @@
 //
 // The Google Cloud Logging API lets you write log entries and manage your
 // logs, log sinks and logs-based metrics.
+//
+// Use the client at cloud.google.com/go/logging in preference to this.
 package logging // import "cloud.google.com/go/logging/apiv2"
 
 const gapicNameVersion = "gapic/0.1.0"

--- a/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/logging_client.go
+++ b/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/logging_client.go
@@ -107,7 +107,7 @@ type Client struct {
 	CallOptions *CallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewClient creates a new logging service v2 client.
@@ -143,9 +143,8 @@ func (c *Client) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *Client) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // LoggingParentPath returns the path for the parent resource.

--- a/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/metrics_client.go
+++ b/generated/go/google-logging-v2/cloud.google.com/go/logging/apiv2/metrics_client.go
@@ -96,7 +96,7 @@ type MetricsClient struct {
 	CallOptions *MetricsCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewMetricsClient creates a new metrics service v2 client.
@@ -132,9 +132,8 @@ func (c *MetricsClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *MetricsClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // MetricsParentPath returns the path for the parent resource.

--- a/generated/go/google-monitoring-v3/cloud.google.com/go/monitoring/apiv3/group_client.go
+++ b/generated/go/google-monitoring-v3/cloud.google.com/go/monitoring/apiv3/group_client.go
@@ -93,7 +93,7 @@ type GroupClient struct {
 	CallOptions *GroupCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewGroupClient creates a new group service client.
@@ -140,9 +140,8 @@ func (c *GroupClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *GroupClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // GroupProjectPath returns the path for the project resource.

--- a/generated/go/google-monitoring-v3/cloud.google.com/go/monitoring/apiv3/metric_client.go
+++ b/generated/go/google-monitoring-v3/cloud.google.com/go/monitoring/apiv3/metric_client.go
@@ -99,7 +99,7 @@ type MetricClient struct {
 	CallOptions *MetricCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewMetricClient creates a new metric service client.
@@ -136,9 +136,8 @@ func (c *MetricClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *MetricClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // MetricProjectPath returns the path for the project resource.

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/doc.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/doc.go
@@ -19,6 +19,8 @@
 //
 // Provides reliable, many-to-many, asynchronous messaging between applications.
 //
+//
+// Use the client at cloud.google.com/go/pubsub in preference to this.
 package pubsub // import "cloud.google.com/go/pubsub/apiv1"
 
 const gapicNameVersion = "gapic/0.1.0"

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client.go
@@ -115,7 +115,7 @@ type PublisherClient struct {
 	CallOptions *PublisherCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewPublisherClient creates a new publisher client.
@@ -153,9 +153,8 @@ func (c *PublisherClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *PublisherClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // PublisherProjectPath returns the path for the project resource.

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client.go
@@ -108,7 +108,7 @@ type SubscriberClient struct {
 	CallOptions *SubscriberCallOptions
 
 	// The metadata to be sent with each request.
-	metadata map[string][]string
+	metadata metadata.MD
 }
 
 // NewSubscriberClient creates a new subscriber client.
@@ -146,9 +146,8 @@ func (c *SubscriberClient) Close() error {
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
 func (c *SubscriberClient) SetGoogleClientInfo(name, version string) {
-	c.metadata = map[string][]string{
-		"x-goog-api-client": {fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())},
-	}
+	v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, runtime.Version())
+	c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 
 // SubscriberProjectPath returns the path for the project resource.


### PR DESCRIPTION
This commit addsa few features
- GRPC streaming
- Metadata fix
- Point to domain layer, if one exists
- Disable iam/admin's Get, Set, and Test methods to be replaced with
  hand-written version