### PR TITLE
Go pubsub/apiv1: Update IAM to use IAM library

### DIFF
--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client.go
@@ -22,12 +22,12 @@ import (
 	"runtime"
 	"time"
 
+	"cloud.google.com/go/iam"
 	gax "github.com/googleapis/gax-go"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	pubsubpb "google.golang.org/genproto/googleapis/pubsub/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -47,9 +47,6 @@ type PublisherCallOptions struct {
 	ListTopics             []gax.CallOption
 	ListTopicSubscriptions []gax.CallOption
 	DeleteTopic            []gax.CallOption
-	SetIamPolicy           []gax.CallOption
-	GetIamPolicy           []gax.CallOption
-	TestIamPermissions     []gax.CallOption
 }
 
 func defaultPublisherClientOptions() []option.ClientOption {
@@ -96,9 +93,6 @@ func defaultPublisherCallOptions() *PublisherCallOptions {
 		ListTopics:             retry[[2]string{"default", "idempotent"}],
 		ListTopicSubscriptions: retry[[2]string{"default", "idempotent"}],
 		DeleteTopic:            retry[[2]string{"default", "idempotent"}],
-		SetIamPolicy:           retry[[2]string{"default", "non_idempotent"}],
-		GetIamPolicy:           retry[[2]string{"default", "idempotent"}],
-		TestIamPermissions:     retry[[2]string{"default", "non_idempotent"}],
 	}
 }
 
@@ -108,7 +102,6 @@ type PublisherClient struct {
 	conn *grpc.ClientConn
 
 	// The gRPC API client.
-	iamPolicyClient iampb.IAMPolicyClient
 	publisherClient pubsubpb.PublisherClient
 
 	// The call options for this service.
@@ -131,7 +124,6 @@ func NewPublisherClient(ctx context.Context, opts ...option.ClientOption) (*Publ
 		conn:        conn,
 		CallOptions: defaultPublisherCallOptions(),
 
-		iamPolicyClient: iampb.NewIAMPolicyClient(conn),
 		publisherClient: pubsubpb.NewPublisherClient(conn),
 	}
 	c.SetGoogleClientInfo("gax", gax.Version)
@@ -178,6 +170,13 @@ func PublisherTopicPath(project, topic string) string {
 		panic(err)
 	}
 	return path
+}
+
+func (c *PublisherClient) SubscriptionIAM(subscription *pubsubpb.Subscription) *iam.Handle {
+	return iam.InternalNewHandle(c.Connection(), subscription.Name)
+}
+func (c *PublisherClient) TopicIAM(topic *pubsubpb.Topic) *iam.Handle {
+	return iam.InternalNewHandle(c.Connection(), topic.Name)
 }
 
 // CreateTopic creates the given topic with the given name.
@@ -316,57 +315,6 @@ func (c *PublisherClient) DeleteTopic(ctx context.Context, req *pubsubpb.DeleteT
 		return err
 	}, c.CallOptions.DeleteTopic...)
 	return err
-}
-
-// SetIamPolicy sets the access control policy on the specified resource. Replaces any
-// existing policy.
-func (c *PublisherClient) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.Policy
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.SetIamPolicy(ctx, req)
-		return err
-	}, c.CallOptions.SetIamPolicy...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// GetIamPolicy gets the access control policy for a resource.
-// Returns an empty policy if the resource exists and does not have a policy
-// set.
-func (c *PublisherClient) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.Policy
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.GetIamPolicy(ctx, req)
-		return err
-	}, c.CallOptions.GetIamPolicy...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// TestIamPermissions returns permissions that a caller has on the specified resource.
-func (c *PublisherClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.TestIamPermissionsResponse
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.TestIamPermissions(ctx, req)
-		return err
-	}, c.CallOptions.TestIamPermissions...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
 }
 
 // StringIterator manages a stream of string.

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client_example_test.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/publisher_client_example_test.go
@@ -19,7 +19,6 @@ package pubsub_test
 import (
 	"cloud.google.com/go/pubsub/apiv1"
 	"golang.org/x/net/context"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	pubsubpb "google.golang.org/genproto/googleapis/pubsub/v1"
 )
 
@@ -31,6 +30,39 @@ func ExampleNewPublisherClient() {
 	}
 	// TODO: Use client.
 	_ = c
+}
+
+func ExamplePublisherClient_SubscriptionIAM() {
+	ctx := context.Background()
+	c, err := pubsub.NewPublisherClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	subscription := &pubsubpb.Subscription{}
+	h := c.SubscriptionIAM(subscription)
+	policy, err := h.Policy(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	//TODO: Use the IAM policy
+	_ = policy
+}
+func ExamplePublisherClient_TopicIAM() {
+	ctx := context.Background()
+	c, err := pubsub.NewPublisherClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	topic := &pubsubpb.Topic{}
+	h := c.TopicIAM(topic)
+	policy, err := h.Policy(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	//TODO: Use the IAM policy
+	_ = policy
 }
 
 func ExamplePublisherClient_CreateTopic() {
@@ -145,58 +177,4 @@ func ExamplePublisherClient_DeleteTopic() {
 	if err != nil {
 		// TODO: Handle error.
 	}
-}
-
-func ExamplePublisherClient_SetIamPolicy() {
-	ctx := context.Background()
-	c, err := pubsub.NewPublisherClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.SetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.SetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExamplePublisherClient_GetIamPolicy() {
-	ctx := context.Background()
-	c, err := pubsub.NewPublisherClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.GetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.GetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExamplePublisherClient_TestIamPermissions() {
-	ctx := context.Background()
-	c, err := pubsub.NewPublisherClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.TestIamPermissionsRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.TestIamPermissions(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
 }

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client.go
@@ -22,12 +22,12 @@ import (
 	"runtime"
 	"time"
 
+	"cloud.google.com/go/iam"
 	gax "github.com/googleapis/gax-go"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	pubsubpb "google.golang.org/genproto/googleapis/pubsub/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -50,9 +50,6 @@ type SubscriberCallOptions struct {
 	Acknowledge        []gax.CallOption
 	Pull               []gax.CallOption
 	ModifyPushConfig   []gax.CallOption
-	SetIamPolicy       []gax.CallOption
-	GetIamPolicy       []gax.CallOption
-	TestIamPermissions []gax.CallOption
 }
 
 func defaultSubscriberClientOptions() []option.ClientOption {
@@ -89,9 +86,6 @@ func defaultSubscriberCallOptions() *SubscriberCallOptions {
 		Acknowledge:        retry[[2]string{"messaging", "non_idempotent"}],
 		Pull:               retry[[2]string{"messaging", "non_idempotent"}],
 		ModifyPushConfig:   retry[[2]string{"default", "non_idempotent"}],
-		SetIamPolicy:       retry[[2]string{"default", "non_idempotent"}],
-		GetIamPolicy:       retry[[2]string{"default", "idempotent"}],
-		TestIamPermissions: retry[[2]string{"default", "non_idempotent"}],
 	}
 }
 
@@ -101,7 +95,6 @@ type SubscriberClient struct {
 	conn *grpc.ClientConn
 
 	// The gRPC API client.
-	iamPolicyClient  iampb.IAMPolicyClient
 	subscriberClient pubsubpb.SubscriberClient
 
 	// The call options for this service.
@@ -124,7 +117,6 @@ func NewSubscriberClient(ctx context.Context, opts ...option.ClientOption) (*Sub
 		conn:        conn,
 		CallOptions: defaultSubscriberCallOptions(),
 
-		iamPolicyClient:  iampb.NewIAMPolicyClient(conn),
 		subscriberClient: pubsubpb.NewSubscriberClient(conn),
 	}
 	c.SetGoogleClientInfo("gax", gax.Version)
@@ -183,6 +175,13 @@ func SubscriberTopicPath(project, topic string) string {
 		panic(err)
 	}
 	return path
+}
+
+func (c *SubscriberClient) SubscriptionIAM(subscription *pubsubpb.Subscription) *iam.Handle {
+	return iam.InternalNewHandle(c.Connection(), subscription.Name)
+}
+func (c *SubscriberClient) TopicIAM(topic *pubsubpb.Topic) *iam.Handle {
+	return iam.InternalNewHandle(c.Connection(), topic.Name)
 }
 
 // CreateSubscription creates a subscription to a given topic.
@@ -343,57 +342,6 @@ func (c *SubscriberClient) ModifyPushConfig(ctx context.Context, req *pubsubpb.M
 		return err
 	}, c.CallOptions.ModifyPushConfig...)
 	return err
-}
-
-// SetIamPolicy sets the access control policy on the specified resource. Replaces any
-// existing policy.
-func (c *SubscriberClient) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.Policy
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.SetIamPolicy(ctx, req)
-		return err
-	}, c.CallOptions.SetIamPolicy...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// GetIamPolicy gets the access control policy for a resource.
-// Returns an empty policy if the resource exists and does not have a policy
-// set.
-func (c *SubscriberClient) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.Policy
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.GetIamPolicy(ctx, req)
-		return err
-	}, c.CallOptions.GetIamPolicy...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// TestIamPermissions returns permissions that a caller has on the specified resource.
-func (c *SubscriberClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
-	md, _ := metadata.FromContext(ctx)
-	ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
-	var resp *iampb.TestIamPermissionsResponse
-	err := gax.Invoke(ctx, func(ctx context.Context) error {
-		var err error
-		resp, err = c.iamPolicyClient.TestIamPermissions(ctx, req)
-		return err
-	}, c.CallOptions.TestIamPermissions...)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
 }
 
 // SubscriptionIterator manages a stream of *pubsubpb.Subscription.

--- a/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client_example_test.go
+++ b/generated/go/google-pubsub-v1/cloud.google.com/go/pubsub/apiv1/subscriber_client_example_test.go
@@ -19,7 +19,6 @@ package pubsub_test
 import (
 	"cloud.google.com/go/pubsub/apiv1"
 	"golang.org/x/net/context"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	pubsubpb "google.golang.org/genproto/googleapis/pubsub/v1"
 )
 
@@ -31,6 +30,39 @@ func ExampleNewSubscriberClient() {
 	}
 	// TODO: Use client.
 	_ = c
+}
+
+func ExampleSubscriberClient_SubscriptionIAM() {
+	ctx := context.Background()
+	c, err := pubsub.NewSubscriberClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	subscription := &pubsubpb.Subscription{}
+	h := c.SubscriptionIAM(subscription)
+	policy, err := h.Policy(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	//TODO: Use the IAM policy
+	_ = policy
+}
+func ExampleSubscriberClient_TopicIAM() {
+	ctx := context.Background()
+	c, err := pubsub.NewSubscriberClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	topic := &pubsubpb.Topic{}
+	h := c.TopicIAM(topic)
+	policy, err := h.Policy(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	//TODO: Use the IAM policy
+	_ = policy
 }
 
 func ExampleSubscriberClient_CreateSubscription() {
@@ -171,58 +203,4 @@ func ExampleSubscriberClient_ModifyPushConfig() {
 	if err != nil {
 		// TODO: Handle error.
 	}
-}
-
-func ExampleSubscriberClient_SetIamPolicy() {
-	ctx := context.Background()
-	c, err := pubsub.NewSubscriberClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.SetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.SetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExampleSubscriberClient_GetIamPolicy() {
-	ctx := context.Background()
-	c, err := pubsub.NewSubscriberClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.GetIamPolicyRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.GetIamPolicy(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
-}
-
-func ExampleSubscriberClient_TestIamPermissions() {
-	ctx := context.Background()
-	c, err := pubsub.NewSubscriberClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-
-	req := &iampb.TestIamPermissionsRequest{
-	// TODO: Fill request struct fields.
-	}
-	resp, err := c.TestIamPermissions(ctx, req)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	// TODO: Use resp.
-	_ = resp
 }


### PR DESCRIPTION
This commit makes PubSub Topic and Subscription use the IAM library
at cloud.google.com/go/iam.

This is the state of the world after the following land:
- https://github.com/googleapis/googleapis/pull/175
- https://github.com/googleapis/toolkit/pull/627