### PR TITLE
Java: regenerating Logging - removing @ExperimentalApi

### DIFF
--- a/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/ConfigServiceV2Client.java
+++ b/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/ConfigServiceV2Client.java
@@ -29,7 +29,6 @@ import com.google.logging.v2.ParentNameOneof;
 import com.google.logging.v2.SinkNameOneof;
 import com.google.logging.v2.UpdateSinkRequest;
 import com.google.protobuf.Empty;
-import com.google.protobuf.ExperimentalApi;
 import io.grpc.ManagedChannel;
 import java.io.Closeable;
 import java.io.IOException;
@@ -96,7 +95,6 @@ import javax.annotation.Generated;
  * </pre>
  */
 @Generated("by GAPIC")
-@ExperimentalApi
 public class ConfigServiceV2Client implements AutoCloseable {
   private final ConfigServiceV2Settings settings;
   private final ScheduledExecutorService executor;

--- a/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/LoggingServiceV2Client.java
+++ b/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/LoggingServiceV2Client.java
@@ -31,7 +31,6 @@ import com.google.logging.v2.LogNameOneof;
 import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
-import com.google.protobuf.ExperimentalApi;
 import io.grpc.ManagedChannel;
 import java.io.Closeable;
 import java.io.IOException;
@@ -98,7 +97,6 @@ import javax.annotation.Generated;
  * </pre>
  */
 @Generated("by GAPIC")
-@ExperimentalApi
 public class LoggingServiceV2Client implements AutoCloseable {
   private final LoggingServiceV2Settings settings;
   private final ScheduledExecutorService executor;

--- a/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/MetricsServiceV2Client.java
+++ b/generated/java/google-cloud-logging-v2/src/main/java/com/google/cloud/logging/spi/v2/MetricsServiceV2Client.java
@@ -29,7 +29,6 @@ import com.google.logging.v2.MetricNameOneof;
 import com.google.logging.v2.ParentNameOneof;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.protobuf.Empty;
-import com.google.protobuf.ExperimentalApi;
 import io.grpc.ManagedChannel;
 import java.io.Closeable;
 import java.io.IOException;
@@ -95,7 +94,6 @@ import javax.annotation.Generated;
  * </pre>
  */
 @Generated("by GAPIC")
-@ExperimentalApi
 public class MetricsServiceV2Client implements AutoCloseable {
   private final MetricsServiceV2Settings settings;
   private final ScheduledExecutorService executor;


### PR DESCRIPTION
Making use of https://github.com/googleapis/toolkit/pull/838 and https://github.com/googleapis/googleapis/pull/212 .