### PR TITLE
Generate beta version of logging with latest grpcio and GAPIC config

### DIFF
--- a/generated/python/gapic-google-cloud-logging-v2/docs/conf.py
+++ b/generated/python/gapic-google-cloud-logging-v2/docs/conf.py
@@ -20,7 +20,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.90.0'
 
 # -- General configuration ------------------------------------------------
 

--- a/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/config_service_v2_client.py
+++ b/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/config_service_v2_client.py
@@ -67,14 +67,14 @@ class ConfigServiceV2Client(object):
         'https://www.googleapis.com/auth/logging.read',
         'https://www.googleapis.com/auth/logging.write', )
 
-    _PARENT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
+    _PROJECT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
     _SINK_PATH_TEMPLATE = path_template.PathTemplate(
         'projects/{project}/sinks/{sink}')
 
     @classmethod
-    def parent_path(cls, project):
-        """Returns a fully-qualified parent resource name string."""
-        return cls._PARENT_PATH_TEMPLATE.render({'project': project, })
+    def project_path(cls, project):
+        """Returns a fully-qualified project resource name string."""
+        return cls._PROJECT_PATH_TEMPLATE.render({'project': project, })
 
     @classmethod
     def sink_path(cls, project, sink):
@@ -85,17 +85,17 @@ class ConfigServiceV2Client(object):
         })
 
     @classmethod
-    def match_project_from_parent_name(cls, parent_name):
-        """Parses the project from a parent resource.
+    def match_project_from_project_name(cls, project_name):
+        """Parses the project from a project resource.
 
         Args:
-          parent_name (string): A fully-qualified path representing a parent
+          project_name (string): A fully-qualified path representing a project
             resource.
 
         Returns:
           A string representing the project.
         """
-        return cls._PARENT_PATH_TEMPLATE.match(parent_name).get('project')
+        return cls._PROJECT_PATH_TEMPLATE.match(project_name).get('project')
 
     @classmethod
     def match_project_from_sink_name(cls, sink_name):
@@ -209,7 +209,7 @@ class ConfigServiceV2Client(object):
           >>> from google.cloud.gapic.logging.v2 import config_service_v2_client
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = config_service_v2_client.ConfigServiceV2Client()
-          >>> parent = api.parent_path('[PROJECT]')
+          >>> parent = api.project_path('[PROJECT]')
           >>>
           >>> # Iterate over all results
           >>> for element in api.list_sinks(parent):
@@ -293,7 +293,7 @@ class ConfigServiceV2Client(object):
           >>> from google.cloud.gapic.logging.v2 import config_service_v2_client
           >>> from google.cloud.grpc.logging.v2 import logging_config_pb2
           >>> api = config_service_v2_client.ConfigServiceV2Client()
-          >>> parent = api.parent_path('[PROJECT]')
+          >>> parent = api.project_path('[PROJECT]')
           >>> sink = logging_config_pb2.LogSink()
           >>> response = api.create_sink(parent, sink)
 

--- a/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/logging_service_v2_client.py
+++ b/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/logging_service_v2_client.py
@@ -69,14 +69,14 @@ class LoggingServiceV2Client(object):
         'https://www.googleapis.com/auth/logging.read',
         'https://www.googleapis.com/auth/logging.write', )
 
-    _PARENT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
+    _PROJECT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
     _LOG_PATH_TEMPLATE = path_template.PathTemplate(
         'projects/{project}/logs/{log}')
 
     @classmethod
-    def parent_path(cls, project):
-        """Returns a fully-qualified parent resource name string."""
-        return cls._PARENT_PATH_TEMPLATE.render({'project': project, })
+    def project_path(cls, project):
+        """Returns a fully-qualified project resource name string."""
+        return cls._PROJECT_PATH_TEMPLATE.render({'project': project, })
 
     @classmethod
     def log_path(cls, project, log):
@@ -87,17 +87,17 @@ class LoggingServiceV2Client(object):
         })
 
     @classmethod
-    def match_project_from_parent_name(cls, parent_name):
-        """Parses the project from a parent resource.
+    def match_project_from_project_name(cls, project_name):
+        """Parses the project from a project resource.
 
         Args:
-          parent_name (string): A fully-qualified path representing a parent
+          project_name (string): A fully-qualified path representing a project
             resource.
 
         Returns:
           A string representing the project.
         """
-        return cls._PARENT_PATH_TEMPLATE.match(parent_name).get('project')
+        return cls._PROJECT_PATH_TEMPLATE.match(project_name).get('project')
 
     @classmethod
     def match_project_from_log_name(cls, log_name):

--- a/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/metrics_service_v2_client.py
+++ b/generated/python/gapic-google-cloud-logging-v2/google/cloud/gapic/logging/v2/metrics_service_v2_client.py
@@ -65,14 +65,14 @@ class MetricsServiceV2Client(object):
         'https://www.googleapis.com/auth/logging.read',
         'https://www.googleapis.com/auth/logging.write', )
 
-    _PARENT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
+    _PROJECT_PATH_TEMPLATE = path_template.PathTemplate('projects/{project}')
     _METRIC_PATH_TEMPLATE = path_template.PathTemplate(
         'projects/{project}/metrics/{metric}')
 
     @classmethod
-    def parent_path(cls, project):
-        """Returns a fully-qualified parent resource name string."""
-        return cls._PARENT_PATH_TEMPLATE.render({'project': project, })
+    def project_path(cls, project):
+        """Returns a fully-qualified project resource name string."""
+        return cls._PROJECT_PATH_TEMPLATE.render({'project': project, })
 
     @classmethod
     def metric_path(cls, project, metric):
@@ -83,17 +83,17 @@ class MetricsServiceV2Client(object):
         })
 
     @classmethod
-    def match_project_from_parent_name(cls, parent_name):
-        """Parses the project from a parent resource.
+    def match_project_from_project_name(cls, project_name):
+        """Parses the project from a project resource.
 
         Args:
-          parent_name (string): A fully-qualified path representing a parent
+          project_name (string): A fully-qualified path representing a project
             resource.
 
         Returns:
           A string representing the project.
         """
-        return cls._PARENT_PATH_TEMPLATE.match(parent_name).get('project')
+        return cls._PROJECT_PATH_TEMPLATE.match(project_name).get('project')
 
     @classmethod
     def match_project_from_metric_name(cls, metric_name):
@@ -208,7 +208,7 @@ class MetricsServiceV2Client(object):
           >>> from google.cloud.gapic.logging.v2 import metrics_service_v2_client
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = metrics_service_v2_client.MetricsServiceV2Client()
-          >>> parent = api.parent_path('[PROJECT]')
+          >>> parent = api.project_path('[PROJECT]')
           >>>
           >>> # Iterate over all results
           >>> for element in api.list_log_metrics(parent):
@@ -287,7 +287,7 @@ class MetricsServiceV2Client(object):
           >>> from google.cloud.gapic.logging.v2 import metrics_service_v2_client
           >>> from google.cloud.grpc.logging.v2 import logging_metrics_pb2
           >>> api = metrics_service_v2_client.MetricsServiceV2Client()
-          >>> parent = api.parent_path('[PROJECT]')
+          >>> parent = api.project_path('[PROJECT]')
           >>> metric = logging_metrics_pb2.LogMetric()
           >>> response = api.create_log_metric(parent, metric)
 

--- a/generated/python/gapic-google-cloud-logging-v2/requirements.txt
+++ b/generated/python/gapic-google-cloud-logging-v2/requirements.txt
@@ -1,4 +1,4 @@
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.15.0, <0.16dev
-grpc-google-cloud-logging-v2>=0.14.0, <0.15.0dev
+grpc-google-cloud-logging-v2>=0.90.0, <0.91dev
 oauth2client>=2.0.0, <4.0dev

--- a/generated/python/gapic-google-cloud-logging-v2/setup.py
+++ b/generated/python/gapic-google-cloud-logging-v2/setup.py
@@ -11,18 +11,18 @@ import sys
 install_requires = [
     'googleapis-common-protos>=1.5.0, <2.0dev',
     'google-gax>=0.15.0, <0.16dev',
-    'grpc-google-cloud-logging-v2>=0.14.0, <0.15.0dev',
+    'grpc-google-cloud-logging-v2>=0.90.0, <0.91dev',
     'oauth2client>=2.0.0, <4.0dev',
 ]
 
 setup(
     name='gapic-google-cloud-logging-v2',
-    version='0.14.1',
+    version='0.90.0',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[
         'Intended Audience :: Developers',
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',

--- a/generated/python/grpc-google-cloud-logging-v2/README.rst
+++ b/generated/python/grpc-google-cloud-logging-v2/README.rst
@@ -1,4 +1,4 @@
-gRPC library for google-logging-v2
+gRPC library for Stackdriver Logging
 
 grpc-google-cloud-logging-v2 is the IDL-derived library for the logging (v2) service in the googleapis_ repository.
 

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/log_entry_pb2.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/log_entry_pb2.py
@@ -26,7 +26,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/cloud/grpc/logging/v2/log_entry.proto',
   package='google.logging.v2',
   syntax='proto3',
-  serialized_pb=_b('\n,google/cloud/grpc/logging/v2/log_entry.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a&google/logging/type/http_request.proto\x1a&google/logging/type/log_severity.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9f\x04\n\x08LogEntry\x12\x10\n\x08log_name\x18\x0c \x01(\t\x12/\n\x08resource\x18\x08 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12-\n\rproto_payload\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00\x12\x16\n\x0ctext_payload\x18\x03 \x01(\tH\x00\x12/\n\x0cjson_payload\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12-\n\ttimestamp\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x32\n\x08severity\x18\n \x01(\x0e\x32 .google.logging.type.LogSeverity\x12\x11\n\tinsert_id\x18\x04 \x01(\t\x12\x36\n\x0chttp_request\x18\x07 \x01(\x0b\x32 .google.logging.type.HttpRequest\x12\x37\n\x06labels\x18\x0b \x03(\x0b\x32\'.google.logging.v2.LogEntry.LabelsEntry\x12\x37\n\toperation\x18\x0f \x01(\x0b\x32$.google.logging.v2.LogEntryOperation\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\t\n\x07payload\"N\n\x11LogEntryOperation\x12\n\n\x02id\x18\x01 \x01(\t\x12\x10\n\x08producer\x18\x02 \x01(\t\x12\r\n\x05\x66irst\x18\x03 \x01(\x08\x12\x0c\n\x04last\x18\x04 \x01(\x08\x42+\n\x15\x63om.google.logging.v2B\rLogEntryProtoP\x01\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n,google/cloud/grpc/logging/v2/log_entry.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a&google/logging/type/http_request.proto\x1a&google/logging/type/log_severity.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9f\x04\n\x08LogEntry\x12\x10\n\x08log_name\x18\x0c \x01(\t\x12/\n\x08resource\x18\x08 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12-\n\rproto_payload\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00\x12\x16\n\x0ctext_payload\x18\x03 \x01(\tH\x00\x12/\n\x0cjson_payload\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12-\n\ttimestamp\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x32\n\x08severity\x18\n \x01(\x0e\x32 .google.logging.type.LogSeverity\x12\x11\n\tinsert_id\x18\x04 \x01(\t\x12\x36\n\x0chttp_request\x18\x07 \x01(\x0b\x32 .google.logging.type.HttpRequest\x12\x37\n\x06labels\x18\x0b \x03(\x0b\x32\'.google.logging.v2.LogEntry.LabelsEntry\x12\x37\n\toperation\x18\x0f \x01(\x0b\x32$.google.logging.v2.LogEntryOperation\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\t\n\x07payload\"N\n\x11LogEntryOperation\x12\n\n\x02id\x18\x01 \x01(\t\x12\x10\n\x08producer\x18\x02 \x01(\t\x12\r\n\x05\x66irst\x18\x03 \x01(\x08\x12\x0c\n\x04last\x18\x04 \x01(\x08\x42\x7f\n\x15\x63om.google.logging.v2B\rLogEntryProtoP\x01Z8google.golang.org/genproto/googleapis/logging/v2;logging\xf8\x01\x01\xaa\x02\x17Google.Cloud.Logging.V2b\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_api_dot_monitored__resource__pb2.DESCRIPTOR,google_dot_logging_dot_type_dot_http__request__pb2.DESCRIPTOR,google_dot_logging_dot_type_dot_log__severity__pb2.DESCRIPTOR,google_dot_protobuf_dot_any__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -271,12 +271,17 @@ _sym_db.RegisterMessage(LogEntryOperation)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\rLogEntryProtoP\001\370\001\001'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\rLogEntryProtoP\001Z8google.golang.org/genproto/googleapis/logging/v2;logging\370\001\001\252\002\027Google.Cloud.Logging.V2'))
 _LOGENTRY_LABELSENTRY.has_options = True
 _LOGENTRY_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-import grpc
-from grpc.beta import implementations as beta_implementations
-from grpc.beta import interfaces as beta_interfaces
-from grpc.framework.common import cardinality
-from grpc.framework.interfaces.face import utilities as face_utilities
+try:
+  # THESE ELEMENTS WILL BE DEPRECATED.
+  # Please use the generated *_pb2_grpc.py files instead.
+  import grpc
+  from grpc.framework.common import cardinality
+  from grpc.framework.interfaces.face import utilities as face_utilities
+  from grpc.beta import implementations as beta_implementations
+  from grpc.beta import interfaces as beta_interfaces
+except ImportError:
+  pass
 # @@protoc_insertion_point(module_scope)

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/log_entry_pb2_grpc.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/log_entry_pb2_grpc.py
@@ -1,0 +1,4 @@
+import grpc
+from grpc.framework.common import cardinality
+from grpc.framework.interfaces.face import utilities as face_utilities
+

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_config_pb2.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_config_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/cloud/grpc/logging/v2/logging_config.proto',
   package='google.logging.v2',
   syntax='proto3',
-  serialized_pb=_b('\n1google/cloud/grpc/logging/v2/logging_config.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbd\x02\n\x07LogSink\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65stination\x18\x03 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12G\n\x15output_version_format\x18\x06 \x01(\x0e\x32(.google.logging.v2.LogSink.VersionFormat\x12\x17\n\x0fwriter_identity\x18\x08 \x01(\t\x12.\n\nstart_time\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"?\n\rVersionFormat\x12\x1e\n\x1aVERSION_FORMAT_UNSPECIFIED\x10\x00\x12\x06\n\x02V2\x10\x01\x12\x06\n\x02V1\x10\x02\"I\n\x10ListSinksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\"W\n\x11ListSinksResponse\x12)\n\x05sinks\x18\x01 \x03(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"#\n\x0eGetSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t\"m\n\x11\x43reateSinkRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12(\n\x04sink\x18\x02 \x01(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x1e\n\x16unique_writer_identity\x18\x03 \x01(\x08\"p\n\x11UpdateSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t\x12(\n\x04sink\x18\x02 \x01(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x1e\n\x16unique_writer_identity\x18\x03 \x01(\x08\"&\n\x11\x44\x65leteSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t2\xfe\x04\n\x0f\x43onfigServiceV2\x12}\n\tListSinks\x12#.google.logging.v2.ListSinksRequest\x1a$.google.logging.v2.ListSinksResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/v2/{parent=projects/*}/sinks\x12t\n\x07GetSink\x12!.google.logging.v2.GetSinkRequest\x1a\x1a.google.logging.v2.LogSink\"*\x82\xd3\xe4\x93\x02$\x12\"/v2/{sink_name=projects/*/sinks/*}\x12{\n\nCreateSink\x12$.google.logging.v2.CreateSinkRequest\x1a\x1a.google.logging.v2.LogSink\"+\x82\xd3\xe4\x93\x02%\"\x1d/v2/{parent=projects/*}/sinks:\x04sink\x12\x80\x01\n\nUpdateSink\x12$.google.logging.v2.UpdateSinkRequest\x1a\x1a.google.logging.v2.LogSink\"0\x82\xd3\xe4\x93\x02*\x1a\"/v2/{sink_name=projects/*/sinks/*}:\x04sink\x12v\n\nDeleteSink\x12$.google.logging.v2.DeleteSinkRequest\x1a\x16.google.protobuf.Empty\"*\x82\xd3\xe4\x93\x02$*\"/v2/{sink_name=projects/*/sinks/*}B(\n\x15\x63om.google.logging.v2B\rLoggingConfigP\x01\x62\x06proto3')
+  serialized_pb=_b('\n1google/cloud/grpc/logging/v2/logging_config.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbd\x02\n\x07LogSink\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65stination\x18\x03 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12G\n\x15output_version_format\x18\x06 \x01(\x0e\x32(.google.logging.v2.LogSink.VersionFormat\x12\x17\n\x0fwriter_identity\x18\x08 \x01(\t\x12.\n\nstart_time\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"?\n\rVersionFormat\x12\x1e\n\x1aVERSION_FORMAT_UNSPECIFIED\x10\x00\x12\x06\n\x02V2\x10\x01\x12\x06\n\x02V1\x10\x02\"I\n\x10ListSinksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\"W\n\x11ListSinksResponse\x12)\n\x05sinks\x18\x01 \x03(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"#\n\x0eGetSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t\"m\n\x11\x43reateSinkRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12(\n\x04sink\x18\x02 \x01(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x1e\n\x16unique_writer_identity\x18\x03 \x01(\x08\"p\n\x11UpdateSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t\x12(\n\x04sink\x18\x02 \x01(\x0b\x32\x1a.google.logging.v2.LogSink\x12\x1e\n\x16unique_writer_identity\x18\x03 \x01(\x08\"&\n\x11\x44\x65leteSinkRequest\x12\x11\n\tsink_name\x18\x01 \x01(\t2\xfe\x04\n\x0f\x43onfigServiceV2\x12}\n\tListSinks\x12#.google.logging.v2.ListSinksRequest\x1a$.google.logging.v2.ListSinksResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/v2/{parent=projects/*}/sinks\x12t\n\x07GetSink\x12!.google.logging.v2.GetSinkRequest\x1a\x1a.google.logging.v2.LogSink\"*\x82\xd3\xe4\x93\x02$\x12\"/v2/{sink_name=projects/*/sinks/*}\x12{\n\nCreateSink\x12$.google.logging.v2.CreateSinkRequest\x1a\x1a.google.logging.v2.LogSink\"+\x82\xd3\xe4\x93\x02%\"\x1d/v2/{parent=projects/*}/sinks:\x04sink\x12\x80\x01\n\nUpdateSink\x12$.google.logging.v2.UpdateSinkRequest\x1a\x1a.google.logging.v2.LogSink\"0\x82\xd3\xe4\x93\x02*\x1a\"/v2/{sink_name=projects/*/sinks/*}:\x04sink\x12v\n\nDeleteSink\x12$.google.logging.v2.DeleteSinkRequest\x1a\x16.google.protobuf.Empty\"*\x82\xd3\xe4\x93\x02$*\"/v2/{sink_name=projects/*/sinks/*}B|\n\x15\x63om.google.logging.v2B\rLoggingConfigP\x01Z8google.golang.org/genproto/googleapis/logging/v2;logging\xaa\x02\x17Google.Cloud.Logging.V2b\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -430,251 +430,256 @@ _sym_db.RegisterMessage(DeleteSinkRequest)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\rLoggingConfigP\001'))
-import grpc
-from grpc.beta import implementations as beta_implementations
-from grpc.beta import interfaces as beta_interfaces
-from grpc.framework.common import cardinality
-from grpc.framework.interfaces.face import utilities as face_utilities
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\rLoggingConfigP\001Z8google.golang.org/genproto/googleapis/logging/v2;logging\252\002\027Google.Cloud.Logging.V2'))
+try:
+  # THESE ELEMENTS WILL BE DEPRECATED.
+  # Please use the generated *_pb2_grpc.py files instead.
+  import grpc
+  from grpc.framework.common import cardinality
+  from grpc.framework.interfaces.face import utilities as face_utilities
+  from grpc.beta import implementations as beta_implementations
+  from grpc.beta import interfaces as beta_interfaces
 
 
-class ConfigServiceV2Stub(object):
-  """Service for configuring sinks used to export log entries outside of
-  Stackdriver Logging.
-  """
-
-  def __init__(self, channel):
-    """Constructor.
-
-    Args:
-      channel: A grpc.Channel.
+  class ConfigServiceV2Stub(object):
+    """Service for configuring sinks used to export log entries outside of
+    Stackdriver Logging.
     """
-    self.ListSinks = channel.unary_unary(
-        '/google.logging.v2.ConfigServiceV2/ListSinks',
-        request_serializer=ListSinksRequest.SerializeToString,
-        response_deserializer=ListSinksResponse.FromString,
-        )
-    self.GetSink = channel.unary_unary(
-        '/google.logging.v2.ConfigServiceV2/GetSink',
-        request_serializer=GetSinkRequest.SerializeToString,
-        response_deserializer=LogSink.FromString,
-        )
-    self.CreateSink = channel.unary_unary(
-        '/google.logging.v2.ConfigServiceV2/CreateSink',
-        request_serializer=CreateSinkRequest.SerializeToString,
-        response_deserializer=LogSink.FromString,
-        )
-    self.UpdateSink = channel.unary_unary(
-        '/google.logging.v2.ConfigServiceV2/UpdateSink',
-        request_serializer=UpdateSinkRequest.SerializeToString,
-        response_deserializer=LogSink.FromString,
-        )
-    self.DeleteSink = channel.unary_unary(
-        '/google.logging.v2.ConfigServiceV2/DeleteSink',
-        request_serializer=DeleteSinkRequest.SerializeToString,
-        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-        )
+
+    def __init__(self, channel):
+      """Constructor.
+
+      Args:
+        channel: A grpc.Channel.
+      """
+      self.ListSinks = channel.unary_unary(
+          '/google.logging.v2.ConfigServiceV2/ListSinks',
+          request_serializer=ListSinksRequest.SerializeToString,
+          response_deserializer=ListSinksResponse.FromString,
+          )
+      self.GetSink = channel.unary_unary(
+          '/google.logging.v2.ConfigServiceV2/GetSink',
+          request_serializer=GetSinkRequest.SerializeToString,
+          response_deserializer=LogSink.FromString,
+          )
+      self.CreateSink = channel.unary_unary(
+          '/google.logging.v2.ConfigServiceV2/CreateSink',
+          request_serializer=CreateSinkRequest.SerializeToString,
+          response_deserializer=LogSink.FromString,
+          )
+      self.UpdateSink = channel.unary_unary(
+          '/google.logging.v2.ConfigServiceV2/UpdateSink',
+          request_serializer=UpdateSinkRequest.SerializeToString,
+          response_deserializer=LogSink.FromString,
+          )
+      self.DeleteSink = channel.unary_unary(
+          '/google.logging.v2.ConfigServiceV2/DeleteSink',
+          request_serializer=DeleteSinkRequest.SerializeToString,
+          response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+          )
 
 
-class ConfigServiceV2Servicer(object):
-  """Service for configuring sinks used to export log entries outside of
-  Stackdriver Logging.
-  """
-
-  def ListSinks(self, request, context):
-    """Lists sinks.
+  class ConfigServiceV2Servicer(object):
+    """Service for configuring sinks used to export log entries outside of
+    Stackdriver Logging.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
 
-  def GetSink(self, request, context):
-    """Gets a sink.
+    def ListSinks(self, request, context):
+      """Lists sinks.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def GetSink(self, request, context):
+      """Gets a sink.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def CreateSink(self, request, context):
+      """Creates a sink.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def UpdateSink(self, request, context):
+      """Updates or creates a sink.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def DeleteSink(self, request, context):
+      """Deletes a sink.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+
+  def add_ConfigServiceV2Servicer_to_server(servicer, server):
+    rpc_method_handlers = {
+        'ListSinks': grpc.unary_unary_rpc_method_handler(
+            servicer.ListSinks,
+            request_deserializer=ListSinksRequest.FromString,
+            response_serializer=ListSinksResponse.SerializeToString,
+        ),
+        'GetSink': grpc.unary_unary_rpc_method_handler(
+            servicer.GetSink,
+            request_deserializer=GetSinkRequest.FromString,
+            response_serializer=LogSink.SerializeToString,
+        ),
+        'CreateSink': grpc.unary_unary_rpc_method_handler(
+            servicer.CreateSink,
+            request_deserializer=CreateSinkRequest.FromString,
+            response_serializer=LogSink.SerializeToString,
+        ),
+        'UpdateSink': grpc.unary_unary_rpc_method_handler(
+            servicer.UpdateSink,
+            request_deserializer=UpdateSinkRequest.FromString,
+            response_serializer=LogSink.SerializeToString,
+        ),
+        'DeleteSink': grpc.unary_unary_rpc_method_handler(
+            servicer.DeleteSink,
+            request_deserializer=DeleteSinkRequest.FromString,
+            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        'google.logging.v2.ConfigServiceV2', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+
+
+  class BetaConfigServiceV2Servicer(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for configuring sinks used to export log entries outside of
+    Stackdriver Logging.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
+    def ListSinks(self, request, context):
+      """Lists sinks.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def GetSink(self, request, context):
+      """Gets a sink.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def CreateSink(self, request, context):
+      """Creates a sink.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def UpdateSink(self, request, context):
+      """Updates or creates a sink.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def DeleteSink(self, request, context):
+      """Deletes a sink.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
-  def CreateSink(self, request, context):
-    """Creates a sink.
+
+  class BetaConfigServiceV2Stub(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for configuring sinks used to export log entries outside of
+    Stackdriver Logging.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def UpdateSink(self, request, context):
-    """Updates or creates a sink.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def DeleteSink(self, request, context):
-    """Deletes a sink.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-
-def add_ConfigServiceV2Servicer_to_server(servicer, server):
-  rpc_method_handlers = {
-      'ListSinks': grpc.unary_unary_rpc_method_handler(
-          servicer.ListSinks,
-          request_deserializer=ListSinksRequest.FromString,
-          response_serializer=ListSinksResponse.SerializeToString,
-      ),
-      'GetSink': grpc.unary_unary_rpc_method_handler(
-          servicer.GetSink,
-          request_deserializer=GetSinkRequest.FromString,
-          response_serializer=LogSink.SerializeToString,
-      ),
-      'CreateSink': grpc.unary_unary_rpc_method_handler(
-          servicer.CreateSink,
-          request_deserializer=CreateSinkRequest.FromString,
-          response_serializer=LogSink.SerializeToString,
-      ),
-      'UpdateSink': grpc.unary_unary_rpc_method_handler(
-          servicer.UpdateSink,
-          request_deserializer=UpdateSinkRequest.FromString,
-          response_serializer=LogSink.SerializeToString,
-      ),
-      'DeleteSink': grpc.unary_unary_rpc_method_handler(
-          servicer.DeleteSink,
-          request_deserializer=DeleteSinkRequest.FromString,
-          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-      ),
-  }
-  generic_handler = grpc.method_handlers_generic_handler(
-      'google.logging.v2.ConfigServiceV2', rpc_method_handlers)
-  server.add_generic_rpc_handlers((generic_handler,))
+    def ListSinks(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Lists sinks.
+      """
+      raise NotImplementedError()
+    ListSinks.future = None
+    def GetSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Gets a sink.
+      """
+      raise NotImplementedError()
+    GetSink.future = None
+    def CreateSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Creates a sink.
+      """
+      raise NotImplementedError()
+    CreateSink.future = None
+    def UpdateSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Updates or creates a sink.
+      """
+      raise NotImplementedError()
+    UpdateSink.future = None
+    def DeleteSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Deletes a sink.
+      """
+      raise NotImplementedError()
+    DeleteSink.future = None
 
 
-class BetaConfigServiceV2Servicer(object):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_ConfigServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for configuring sinks used to export log entries outside of
-  Stackdriver Logging.
-  """
-  def ListSinks(self, request, context):
-    """Lists sinks.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def GetSink(self, request, context):
-    """Gets a sink.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def CreateSink(self, request, context):
-    """Creates a sink.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def UpdateSink(self, request, context):
-    """Updates or creates a sink.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def DeleteSink(self, request, context):
-    """Deletes a sink.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-
-
-class BetaConfigServiceV2Stub(object):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for configuring sinks used to export log entries outside of
-  Stackdriver Logging.
-  """
-  def ListSinks(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Lists sinks.
-    """
-    raise NotImplementedError()
-  ListSinks.future = None
-  def GetSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Gets a sink.
-    """
-    raise NotImplementedError()
-  GetSink.future = None
-  def CreateSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Creates a sink.
-    """
-    raise NotImplementedError()
-  CreateSink.future = None
-  def UpdateSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Updates or creates a sink.
-    """
-    raise NotImplementedError()
-  UpdateSink.future = None
-  def DeleteSink(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Deletes a sink.
-    """
-    raise NotImplementedError()
-  DeleteSink.future = None
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_deserializers = {
+      ('google.logging.v2.ConfigServiceV2', 'CreateSink'): CreateSinkRequest.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): DeleteSinkRequest.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'GetSink'): GetSinkRequest.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksRequest.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): UpdateSinkRequest.FromString,
+    }
+    response_serializers = {
+      ('google.logging.v2.ConfigServiceV2', 'CreateSink'): LogSink.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'GetSink'): LogSink.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksResponse.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): LogSink.SerializeToString,
+    }
+    method_implementations = {
+      ('google.logging.v2.ConfigServiceV2', 'CreateSink'): face_utilities.unary_unary_inline(servicer.CreateSink),
+      ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): face_utilities.unary_unary_inline(servicer.DeleteSink),
+      ('google.logging.v2.ConfigServiceV2', 'GetSink'): face_utilities.unary_unary_inline(servicer.GetSink),
+      ('google.logging.v2.ConfigServiceV2', 'ListSinks'): face_utilities.unary_unary_inline(servicer.ListSinks),
+      ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): face_utilities.unary_unary_inline(servicer.UpdateSink),
+    }
+    server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
+    return beta_implementations.server(method_implementations, options=server_options)
 
 
-def beta_create_ConfigServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_ConfigServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_deserializers = {
-    ('google.logging.v2.ConfigServiceV2', 'CreateSink'): CreateSinkRequest.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): DeleteSinkRequest.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'GetSink'): GetSinkRequest.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksRequest.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): UpdateSinkRequest.FromString,
-  }
-  response_serializers = {
-    ('google.logging.v2.ConfigServiceV2', 'CreateSink'): LogSink.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'GetSink'): LogSink.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksResponse.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): LogSink.SerializeToString,
-  }
-  method_implementations = {
-    ('google.logging.v2.ConfigServiceV2', 'CreateSink'): face_utilities.unary_unary_inline(servicer.CreateSink),
-    ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): face_utilities.unary_unary_inline(servicer.DeleteSink),
-    ('google.logging.v2.ConfigServiceV2', 'GetSink'): face_utilities.unary_unary_inline(servicer.GetSink),
-    ('google.logging.v2.ConfigServiceV2', 'ListSinks'): face_utilities.unary_unary_inline(servicer.ListSinks),
-    ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): face_utilities.unary_unary_inline(servicer.UpdateSink),
-  }
-  server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
-  return beta_implementations.server(method_implementations, options=server_options)
-
-
-def beta_create_ConfigServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_serializers = {
-    ('google.logging.v2.ConfigServiceV2', 'CreateSink'): CreateSinkRequest.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): DeleteSinkRequest.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'GetSink'): GetSinkRequest.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksRequest.SerializeToString,
-    ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): UpdateSinkRequest.SerializeToString,
-  }
-  response_deserializers = {
-    ('google.logging.v2.ConfigServiceV2', 'CreateSink'): LogSink.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'GetSink'): LogSink.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksResponse.FromString,
-    ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): LogSink.FromString,
-  }
-  cardinalities = {
-    'CreateSink': cardinality.Cardinality.UNARY_UNARY,
-    'DeleteSink': cardinality.Cardinality.UNARY_UNARY,
-    'GetSink': cardinality.Cardinality.UNARY_UNARY,
-    'ListSinks': cardinality.Cardinality.UNARY_UNARY,
-    'UpdateSink': cardinality.Cardinality.UNARY_UNARY,
-  }
-  stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
-  return beta_implementations.dynamic_stub(channel, 'google.logging.v2.ConfigServiceV2', cardinalities, options=stub_options)
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_serializers = {
+      ('google.logging.v2.ConfigServiceV2', 'CreateSink'): CreateSinkRequest.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): DeleteSinkRequest.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'GetSink'): GetSinkRequest.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksRequest.SerializeToString,
+      ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): UpdateSinkRequest.SerializeToString,
+    }
+    response_deserializers = {
+      ('google.logging.v2.ConfigServiceV2', 'CreateSink'): LogSink.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'DeleteSink'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'GetSink'): LogSink.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'ListSinks'): ListSinksResponse.FromString,
+      ('google.logging.v2.ConfigServiceV2', 'UpdateSink'): LogSink.FromString,
+    }
+    cardinalities = {
+      'CreateSink': cardinality.Cardinality.UNARY_UNARY,
+      'DeleteSink': cardinality.Cardinality.UNARY_UNARY,
+      'GetSink': cardinality.Cardinality.UNARY_UNARY,
+      'ListSinks': cardinality.Cardinality.UNARY_UNARY,
+      'UpdateSink': cardinality.Cardinality.UNARY_UNARY,
+    }
+    stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
+    return beta_implementations.dynamic_stub(channel, 'google.logging.v2.ConfigServiceV2', cardinalities, options=stub_options)
+except ImportError:
+  pass
 # @@protoc_insertion_point(module_scope)

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_config_pb2_grpc.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_config_pb2_grpc.py
@@ -1,0 +1,126 @@
+import grpc
+from grpc.framework.common import cardinality
+from grpc.framework.interfaces.face import utilities as face_utilities
+
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.cloud.grpc.logging.v2.logging_config_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2
+import google.protobuf.empty_pb2 as google_dot_protobuf_dot_empty__pb2
+
+
+class ConfigServiceV2Stub(object):
+  """Service for configuring sinks used to export log entries outside of
+  Stackdriver Logging.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.ListSinks = channel.unary_unary(
+        '/google.logging.v2.ConfigServiceV2/ListSinks',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.ListSinksRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.ListSinksResponse.FromString,
+        )
+    self.GetSink = channel.unary_unary(
+        '/google.logging.v2.ConfigServiceV2/GetSink',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.GetSinkRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.FromString,
+        )
+    self.CreateSink = channel.unary_unary(
+        '/google.logging.v2.ConfigServiceV2/CreateSink',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.CreateSinkRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.FromString,
+        )
+    self.UpdateSink = channel.unary_unary(
+        '/google.logging.v2.ConfigServiceV2/UpdateSink',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.UpdateSinkRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.FromString,
+        )
+    self.DeleteSink = channel.unary_unary(
+        '/google.logging.v2.ConfigServiceV2/DeleteSink',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.DeleteSinkRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+
+
+class ConfigServiceV2Servicer(object):
+  """Service for configuring sinks used to export log entries outside of
+  Stackdriver Logging.
+  """
+
+  def ListSinks(self, request, context):
+    """Lists sinks.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetSink(self, request, context):
+    """Gets a sink.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CreateSink(self, request, context):
+    """Creates a sink.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def UpdateSink(self, request, context):
+    """Updates or creates a sink.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteSink(self, request, context):
+    """Deletes a sink.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_ConfigServiceV2Servicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'ListSinks': grpc.unary_unary_rpc_method_handler(
+          servicer.ListSinks,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.ListSinksRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.ListSinksResponse.SerializeToString,
+      ),
+      'GetSink': grpc.unary_unary_rpc_method_handler(
+          servicer.GetSink,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.GetSinkRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.SerializeToString,
+      ),
+      'CreateSink': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateSink,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.CreateSinkRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.SerializeToString,
+      ),
+      'UpdateSink': grpc.unary_unary_rpc_method_handler(
+          servicer.UpdateSink,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.UpdateSinkRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.LogSink.SerializeToString,
+      ),
+      'DeleteSink': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteSink,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__config__pb2.DeleteSinkRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.logging.v2.ConfigServiceV2', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_metrics_pb2.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_metrics_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/cloud/grpc/logging/v2/logging_metrics.proto',
   package='google.logging.v2',
   syntax='proto3',
-  serialized_pb=_b('\n2google/cloud/grpc/logging/v2/logging_metrics.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x96\x01\n\tLogMetric\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x03 \x01(\t\x12\x38\n\x07version\x18\x04 \x01(\x0e\x32\'.google.logging.v2.LogMetric.ApiVersion\"\x1c\n\nApiVersion\x12\x06\n\x02V2\x10\x00\x12\x06\n\x02V1\x10\x01\"N\n\x15ListLogMetricsRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\"`\n\x16ListLogMetricsResponse\x12-\n\x07metrics\x18\x01 \x03(\x0b\x32\x1c.google.logging.v2.LogMetric\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"*\n\x13GetLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t\"V\n\x16\x43reateLogMetricRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12,\n\x06metric\x18\x02 \x01(\x0b\x32\x1c.google.logging.v2.LogMetric\"[\n\x16UpdateLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t\x12,\n\x06metric\x18\x02 \x01(\x0b\x32\x1c.google.logging.v2.LogMetric\"-\n\x16\x44\x65leteLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t2\xd4\x05\n\x10MetricsServiceV2\x12\x8e\x01\n\x0eListLogMetrics\x12(.google.logging.v2.ListLogMetricsRequest\x1a).google.logging.v2.ListLogMetricsResponse\"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v2/{parent=projects/*}/metrics\x12\x84\x01\n\x0cGetLogMetric\x12&.google.logging.v2.GetLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\".\x82\xd3\xe4\x93\x02(\x12&/v2/{metric_name=projects/*/metrics/*}\x12\x8b\x01\n\x0f\x43reateLogMetric\x12).google.logging.v2.CreateLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\"/\x82\xd3\xe4\x93\x02)\"\x1f/v2/{parent=projects/*}/metrics:\x06metric\x12\x92\x01\n\x0fUpdateLogMetric\x12).google.logging.v2.UpdateLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\"6\x82\xd3\xe4\x93\x02\x30\x1a&/v2/{metric_name=projects/*/metrics/*}:\x06metric\x12\x84\x01\n\x0f\x44\x65leteLogMetric\x12).google.logging.v2.DeleteLogMetricRequest\x1a\x16.google.protobuf.Empty\".\x82\xd3\xe4\x93\x02(*&/v2/{metric_name=projects/*/metrics/*}B)\n\x15\x63om.google.logging.v2B\x0eLoggingMetricsP\x01\x62\x06proto3')
+  serialized_pb=_b('\n2google/cloud/grpc/logging/v2/logging_metrics.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x96\x01\n\tLogMetric\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x03 \x01(\t\x12\x38\n\x07version\x18\x04 \x01(\x0e\x32\'.google.logging.v2.LogMetric.ApiVersion\"\x1c\n\nApiVersion\x12\x06\n\x02V2\x10\x00\x12\x06\n\x02V1\x10\x01\"N\n\x15ListLogMetricsRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\"`\n\x16ListLogMetricsResponse\x12-\n\x07metrics\x18\x01 \x03(\x0b\x32\x1c.google.logging.v2.LogMetric\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"*\n\x13GetLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t\"V\n\x16\x43reateLogMetricRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12,\n\x06metric\x18\x02 \x01(\x0b\x32\x1c.google.logging.v2.LogMetric\"[\n\x16UpdateLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t\x12,\n\x06metric\x18\x02 \x01(\x0b\x32\x1c.google.logging.v2.LogMetric\"-\n\x16\x44\x65leteLogMetricRequest\x12\x13\n\x0bmetric_name\x18\x01 \x01(\t2\xd4\x05\n\x10MetricsServiceV2\x12\x8e\x01\n\x0eListLogMetrics\x12(.google.logging.v2.ListLogMetricsRequest\x1a).google.logging.v2.ListLogMetricsResponse\"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v2/{parent=projects/*}/metrics\x12\x84\x01\n\x0cGetLogMetric\x12&.google.logging.v2.GetLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\".\x82\xd3\xe4\x93\x02(\x12&/v2/{metric_name=projects/*/metrics/*}\x12\x8b\x01\n\x0f\x43reateLogMetric\x12).google.logging.v2.CreateLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\"/\x82\xd3\xe4\x93\x02)\"\x1f/v2/{parent=projects/*}/metrics:\x06metric\x12\x92\x01\n\x0fUpdateLogMetric\x12).google.logging.v2.UpdateLogMetricRequest\x1a\x1c.google.logging.v2.LogMetric\"6\x82\xd3\xe4\x93\x02\x30\x1a&/v2/{metric_name=projects/*/metrics/*}:\x06metric\x12\x84\x01\n\x0f\x44\x65leteLogMetric\x12).google.logging.v2.DeleteLogMetricRequest\x1a\x16.google.protobuf.Empty\".\x82\xd3\xe4\x93\x02(*&/v2/{metric_name=projects/*/metrics/*}B}\n\x15\x63om.google.logging.v2B\x0eLoggingMetricsP\x01Z8google.golang.org/genproto/googleapis/logging/v2;logging\xaa\x02\x17Google.Cloud.Logging.V2b\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -388,247 +388,252 @@ _sym_db.RegisterMessage(DeleteLogMetricRequest)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\016LoggingMetricsP\001'))
-import grpc
-from grpc.beta import implementations as beta_implementations
-from grpc.beta import interfaces as beta_interfaces
-from grpc.framework.common import cardinality
-from grpc.framework.interfaces.face import utilities as face_utilities
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\016LoggingMetricsP\001Z8google.golang.org/genproto/googleapis/logging/v2;logging\252\002\027Google.Cloud.Logging.V2'))
+try:
+  # THESE ELEMENTS WILL BE DEPRECATED.
+  # Please use the generated *_pb2_grpc.py files instead.
+  import grpc
+  from grpc.framework.common import cardinality
+  from grpc.framework.interfaces.face import utilities as face_utilities
+  from grpc.beta import implementations as beta_implementations
+  from grpc.beta import interfaces as beta_interfaces
 
 
-class MetricsServiceV2Stub(object):
-  """Service for configuring logs-based metrics.
-  """
-
-  def __init__(self, channel):
-    """Constructor.
-
-    Args:
-      channel: A grpc.Channel.
+  class MetricsServiceV2Stub(object):
+    """Service for configuring logs-based metrics.
     """
-    self.ListLogMetrics = channel.unary_unary(
-        '/google.logging.v2.MetricsServiceV2/ListLogMetrics',
-        request_serializer=ListLogMetricsRequest.SerializeToString,
-        response_deserializer=ListLogMetricsResponse.FromString,
-        )
-    self.GetLogMetric = channel.unary_unary(
-        '/google.logging.v2.MetricsServiceV2/GetLogMetric',
-        request_serializer=GetLogMetricRequest.SerializeToString,
-        response_deserializer=LogMetric.FromString,
-        )
-    self.CreateLogMetric = channel.unary_unary(
-        '/google.logging.v2.MetricsServiceV2/CreateLogMetric',
-        request_serializer=CreateLogMetricRequest.SerializeToString,
-        response_deserializer=LogMetric.FromString,
-        )
-    self.UpdateLogMetric = channel.unary_unary(
-        '/google.logging.v2.MetricsServiceV2/UpdateLogMetric',
-        request_serializer=UpdateLogMetricRequest.SerializeToString,
-        response_deserializer=LogMetric.FromString,
-        )
-    self.DeleteLogMetric = channel.unary_unary(
-        '/google.logging.v2.MetricsServiceV2/DeleteLogMetric',
-        request_serializer=DeleteLogMetricRequest.SerializeToString,
-        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-        )
+
+    def __init__(self, channel):
+      """Constructor.
+
+      Args:
+        channel: A grpc.Channel.
+      """
+      self.ListLogMetrics = channel.unary_unary(
+          '/google.logging.v2.MetricsServiceV2/ListLogMetrics',
+          request_serializer=ListLogMetricsRequest.SerializeToString,
+          response_deserializer=ListLogMetricsResponse.FromString,
+          )
+      self.GetLogMetric = channel.unary_unary(
+          '/google.logging.v2.MetricsServiceV2/GetLogMetric',
+          request_serializer=GetLogMetricRequest.SerializeToString,
+          response_deserializer=LogMetric.FromString,
+          )
+      self.CreateLogMetric = channel.unary_unary(
+          '/google.logging.v2.MetricsServiceV2/CreateLogMetric',
+          request_serializer=CreateLogMetricRequest.SerializeToString,
+          response_deserializer=LogMetric.FromString,
+          )
+      self.UpdateLogMetric = channel.unary_unary(
+          '/google.logging.v2.MetricsServiceV2/UpdateLogMetric',
+          request_serializer=UpdateLogMetricRequest.SerializeToString,
+          response_deserializer=LogMetric.FromString,
+          )
+      self.DeleteLogMetric = channel.unary_unary(
+          '/google.logging.v2.MetricsServiceV2/DeleteLogMetric',
+          request_serializer=DeleteLogMetricRequest.SerializeToString,
+          response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+          )
 
 
-class MetricsServiceV2Servicer(object):
-  """Service for configuring logs-based metrics.
-  """
-
-  def ListLogMetrics(self, request, context):
-    """Lists logs-based metrics.
+  class MetricsServiceV2Servicer(object):
+    """Service for configuring logs-based metrics.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
 
-  def GetLogMetric(self, request, context):
-    """Gets a logs-based metric.
+    def ListLogMetrics(self, request, context):
+      """Lists logs-based metrics.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def GetLogMetric(self, request, context):
+      """Gets a logs-based metric.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def CreateLogMetric(self, request, context):
+      """Creates a logs-based metric.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def UpdateLogMetric(self, request, context):
+      """Creates or updates a logs-based metric.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def DeleteLogMetric(self, request, context):
+      """Deletes a logs-based metric.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+
+  def add_MetricsServiceV2Servicer_to_server(servicer, server):
+    rpc_method_handlers = {
+        'ListLogMetrics': grpc.unary_unary_rpc_method_handler(
+            servicer.ListLogMetrics,
+            request_deserializer=ListLogMetricsRequest.FromString,
+            response_serializer=ListLogMetricsResponse.SerializeToString,
+        ),
+        'GetLogMetric': grpc.unary_unary_rpc_method_handler(
+            servicer.GetLogMetric,
+            request_deserializer=GetLogMetricRequest.FromString,
+            response_serializer=LogMetric.SerializeToString,
+        ),
+        'CreateLogMetric': grpc.unary_unary_rpc_method_handler(
+            servicer.CreateLogMetric,
+            request_deserializer=CreateLogMetricRequest.FromString,
+            response_serializer=LogMetric.SerializeToString,
+        ),
+        'UpdateLogMetric': grpc.unary_unary_rpc_method_handler(
+            servicer.UpdateLogMetric,
+            request_deserializer=UpdateLogMetricRequest.FromString,
+            response_serializer=LogMetric.SerializeToString,
+        ),
+        'DeleteLogMetric': grpc.unary_unary_rpc_method_handler(
+            servicer.DeleteLogMetric,
+            request_deserializer=DeleteLogMetricRequest.FromString,
+            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        'google.logging.v2.MetricsServiceV2', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+
+
+  class BetaMetricsServiceV2Servicer(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for configuring logs-based metrics.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
+    def ListLogMetrics(self, request, context):
+      """Lists logs-based metrics.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def GetLogMetric(self, request, context):
+      """Gets a logs-based metric.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def CreateLogMetric(self, request, context):
+      """Creates a logs-based metric.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def UpdateLogMetric(self, request, context):
+      """Creates or updates a logs-based metric.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def DeleteLogMetric(self, request, context):
+      """Deletes a logs-based metric.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
-  def CreateLogMetric(self, request, context):
-    """Creates a logs-based metric.
+
+  class BetaMetricsServiceV2Stub(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for configuring logs-based metrics.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def UpdateLogMetric(self, request, context):
-    """Creates or updates a logs-based metric.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def DeleteLogMetric(self, request, context):
-    """Deletes a logs-based metric.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-
-def add_MetricsServiceV2Servicer_to_server(servicer, server):
-  rpc_method_handlers = {
-      'ListLogMetrics': grpc.unary_unary_rpc_method_handler(
-          servicer.ListLogMetrics,
-          request_deserializer=ListLogMetricsRequest.FromString,
-          response_serializer=ListLogMetricsResponse.SerializeToString,
-      ),
-      'GetLogMetric': grpc.unary_unary_rpc_method_handler(
-          servicer.GetLogMetric,
-          request_deserializer=GetLogMetricRequest.FromString,
-          response_serializer=LogMetric.SerializeToString,
-      ),
-      'CreateLogMetric': grpc.unary_unary_rpc_method_handler(
-          servicer.CreateLogMetric,
-          request_deserializer=CreateLogMetricRequest.FromString,
-          response_serializer=LogMetric.SerializeToString,
-      ),
-      'UpdateLogMetric': grpc.unary_unary_rpc_method_handler(
-          servicer.UpdateLogMetric,
-          request_deserializer=UpdateLogMetricRequest.FromString,
-          response_serializer=LogMetric.SerializeToString,
-      ),
-      'DeleteLogMetric': grpc.unary_unary_rpc_method_handler(
-          servicer.DeleteLogMetric,
-          request_deserializer=DeleteLogMetricRequest.FromString,
-          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-      ),
-  }
-  generic_handler = grpc.method_handlers_generic_handler(
-      'google.logging.v2.MetricsServiceV2', rpc_method_handlers)
-  server.add_generic_rpc_handlers((generic_handler,))
+    def ListLogMetrics(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Lists logs-based metrics.
+      """
+      raise NotImplementedError()
+    ListLogMetrics.future = None
+    def GetLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Gets a logs-based metric.
+      """
+      raise NotImplementedError()
+    GetLogMetric.future = None
+    def CreateLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Creates a logs-based metric.
+      """
+      raise NotImplementedError()
+    CreateLogMetric.future = None
+    def UpdateLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Creates or updates a logs-based metric.
+      """
+      raise NotImplementedError()
+    UpdateLogMetric.future = None
+    def DeleteLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Deletes a logs-based metric.
+      """
+      raise NotImplementedError()
+    DeleteLogMetric.future = None
 
 
-class BetaMetricsServiceV2Servicer(object):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_MetricsServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for configuring logs-based metrics.
-  """
-  def ListLogMetrics(self, request, context):
-    """Lists logs-based metrics.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def GetLogMetric(self, request, context):
-    """Gets a logs-based metric.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def CreateLogMetric(self, request, context):
-    """Creates a logs-based metric.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def UpdateLogMetric(self, request, context):
-    """Creates or updates a logs-based metric.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def DeleteLogMetric(self, request, context):
-    """Deletes a logs-based metric.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-
-
-class BetaMetricsServiceV2Stub(object):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for configuring logs-based metrics.
-  """
-  def ListLogMetrics(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Lists logs-based metrics.
-    """
-    raise NotImplementedError()
-  ListLogMetrics.future = None
-  def GetLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Gets a logs-based metric.
-    """
-    raise NotImplementedError()
-  GetLogMetric.future = None
-  def CreateLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Creates a logs-based metric.
-    """
-    raise NotImplementedError()
-  CreateLogMetric.future = None
-  def UpdateLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Creates or updates a logs-based metric.
-    """
-    raise NotImplementedError()
-  UpdateLogMetric.future = None
-  def DeleteLogMetric(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Deletes a logs-based metric.
-    """
-    raise NotImplementedError()
-  DeleteLogMetric.future = None
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_deserializers = {
+      ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): CreateLogMetricRequest.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): DeleteLogMetricRequest.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): GetLogMetricRequest.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsRequest.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): UpdateLogMetricRequest.FromString,
+    }
+    response_serializers = {
+      ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): LogMetric.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): LogMetric.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsResponse.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): LogMetric.SerializeToString,
+    }
+    method_implementations = {
+      ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): face_utilities.unary_unary_inline(servicer.CreateLogMetric),
+      ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): face_utilities.unary_unary_inline(servicer.DeleteLogMetric),
+      ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): face_utilities.unary_unary_inline(servicer.GetLogMetric),
+      ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): face_utilities.unary_unary_inline(servicer.ListLogMetrics),
+      ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): face_utilities.unary_unary_inline(servicer.UpdateLogMetric),
+    }
+    server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
+    return beta_implementations.server(method_implementations, options=server_options)
 
 
-def beta_create_MetricsServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_MetricsServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_deserializers = {
-    ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): CreateLogMetricRequest.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): DeleteLogMetricRequest.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): GetLogMetricRequest.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsRequest.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): UpdateLogMetricRequest.FromString,
-  }
-  response_serializers = {
-    ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): LogMetric.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): LogMetric.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsResponse.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): LogMetric.SerializeToString,
-  }
-  method_implementations = {
-    ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): face_utilities.unary_unary_inline(servicer.CreateLogMetric),
-    ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): face_utilities.unary_unary_inline(servicer.DeleteLogMetric),
-    ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): face_utilities.unary_unary_inline(servicer.GetLogMetric),
-    ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): face_utilities.unary_unary_inline(servicer.ListLogMetrics),
-    ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): face_utilities.unary_unary_inline(servicer.UpdateLogMetric),
-  }
-  server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
-  return beta_implementations.server(method_implementations, options=server_options)
-
-
-def beta_create_MetricsServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_serializers = {
-    ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): CreateLogMetricRequest.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): DeleteLogMetricRequest.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): GetLogMetricRequest.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsRequest.SerializeToString,
-    ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): UpdateLogMetricRequest.SerializeToString,
-  }
-  response_deserializers = {
-    ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): LogMetric.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): LogMetric.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsResponse.FromString,
-    ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): LogMetric.FromString,
-  }
-  cardinalities = {
-    'CreateLogMetric': cardinality.Cardinality.UNARY_UNARY,
-    'DeleteLogMetric': cardinality.Cardinality.UNARY_UNARY,
-    'GetLogMetric': cardinality.Cardinality.UNARY_UNARY,
-    'ListLogMetrics': cardinality.Cardinality.UNARY_UNARY,
-    'UpdateLogMetric': cardinality.Cardinality.UNARY_UNARY,
-  }
-  stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
-  return beta_implementations.dynamic_stub(channel, 'google.logging.v2.MetricsServiceV2', cardinalities, options=stub_options)
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_serializers = {
+      ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): CreateLogMetricRequest.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): DeleteLogMetricRequest.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): GetLogMetricRequest.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsRequest.SerializeToString,
+      ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): UpdateLogMetricRequest.SerializeToString,
+    }
+    response_deserializers = {
+      ('google.logging.v2.MetricsServiceV2', 'CreateLogMetric'): LogMetric.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'DeleteLogMetric'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'GetLogMetric'): LogMetric.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'ListLogMetrics'): ListLogMetricsResponse.FromString,
+      ('google.logging.v2.MetricsServiceV2', 'UpdateLogMetric'): LogMetric.FromString,
+    }
+    cardinalities = {
+      'CreateLogMetric': cardinality.Cardinality.UNARY_UNARY,
+      'DeleteLogMetric': cardinality.Cardinality.UNARY_UNARY,
+      'GetLogMetric': cardinality.Cardinality.UNARY_UNARY,
+      'ListLogMetrics': cardinality.Cardinality.UNARY_UNARY,
+      'UpdateLogMetric': cardinality.Cardinality.UNARY_UNARY,
+    }
+    stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
+    return beta_implementations.dynamic_stub(channel, 'google.logging.v2.MetricsServiceV2', cardinalities, options=stub_options)
+except ImportError:
+  pass
 # @@protoc_insertion_point(module_scope)

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_metrics_pb2_grpc.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_metrics_pb2_grpc.py
@@ -1,0 +1,124 @@
+import grpc
+from grpc.framework.common import cardinality
+from grpc.framework.interfaces.face import utilities as face_utilities
+
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.cloud.grpc.logging.v2.logging_metrics_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2
+import google.protobuf.empty_pb2 as google_dot_protobuf_dot_empty__pb2
+
+
+class MetricsServiceV2Stub(object):
+  """Service for configuring logs-based metrics.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.ListLogMetrics = channel.unary_unary(
+        '/google.logging.v2.MetricsServiceV2/ListLogMetrics',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.ListLogMetricsRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.ListLogMetricsResponse.FromString,
+        )
+    self.GetLogMetric = channel.unary_unary(
+        '/google.logging.v2.MetricsServiceV2/GetLogMetric',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.GetLogMetricRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.FromString,
+        )
+    self.CreateLogMetric = channel.unary_unary(
+        '/google.logging.v2.MetricsServiceV2/CreateLogMetric',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.CreateLogMetricRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.FromString,
+        )
+    self.UpdateLogMetric = channel.unary_unary(
+        '/google.logging.v2.MetricsServiceV2/UpdateLogMetric',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.UpdateLogMetricRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.FromString,
+        )
+    self.DeleteLogMetric = channel.unary_unary(
+        '/google.logging.v2.MetricsServiceV2/DeleteLogMetric',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.DeleteLogMetricRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+
+
+class MetricsServiceV2Servicer(object):
+  """Service for configuring logs-based metrics.
+  """
+
+  def ListLogMetrics(self, request, context):
+    """Lists logs-based metrics.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetLogMetric(self, request, context):
+    """Gets a logs-based metric.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CreateLogMetric(self, request, context):
+    """Creates a logs-based metric.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def UpdateLogMetric(self, request, context):
+    """Creates or updates a logs-based metric.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteLogMetric(self, request, context):
+    """Deletes a logs-based metric.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_MetricsServiceV2Servicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'ListLogMetrics': grpc.unary_unary_rpc_method_handler(
+          servicer.ListLogMetrics,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.ListLogMetricsRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.ListLogMetricsResponse.SerializeToString,
+      ),
+      'GetLogMetric': grpc.unary_unary_rpc_method_handler(
+          servicer.GetLogMetric,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.GetLogMetricRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.SerializeToString,
+      ),
+      'CreateLogMetric': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateLogMetric,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.CreateLogMetricRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.SerializeToString,
+      ),
+      'UpdateLogMetric': grpc.unary_unary_rpc_method_handler(
+          servicer.UpdateLogMetric,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.UpdateLogMetricRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.LogMetric.SerializeToString,
+      ),
+      'DeleteLogMetric': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteLogMetric,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__metrics__pb2.DeleteLogMetricRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.logging.v2.MetricsServiceV2', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_pb2.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_pb2.py
@@ -26,7 +26,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/cloud/grpc/logging/v2/logging.proto',
   package='google.logging.v2',
   syntax='proto3',
-  serialized_pb=_b('\n*google/cloud/grpc/logging/v2/logging.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a,google/cloud/grpc/logging/v2/log_entry.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\"$\n\x10\x44\x65leteLogRequest\x12\x10\n\x08log_name\x18\x01 \x01(\t\"\x98\x02\n\x16WriteLogEntriesRequest\x12\x10\n\x08log_name\x18\x01 \x01(\t\x12/\n\x08resource\x18\x02 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12\x45\n\x06labels\x18\x03 \x03(\x0b\x32\x35.google.logging.v2.WriteLogEntriesRequest.LabelsEntry\x12,\n\x07\x65ntries\x18\x04 \x03(\x0b\x32\x1b.google.logging.v2.LogEntry\x12\x17\n\x0fpartial_success\x18\x05 \x01(\x08\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x19\n\x17WriteLogEntriesResponse\"\x8d\x01\n\x15ListLogEntriesRequest\x12\x13\n\x0bproject_ids\x18\x01 \x03(\t\x12\x16\n\x0eresource_names\x18\x08 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x10\n\x08order_by\x18\x03 \x01(\t\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"_\n\x16ListLogEntriesResponse\x12,\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x1b.google.logging.v2.LogEntry\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"P\n\'ListMonitoredResourceDescriptorsRequest\x12\x11\n\tpage_size\x18\x01 \x01(\x05\x12\x12\n\npage_token\x18\x02 \x01(\t\"\x8a\x01\n(ListMonitoredResourceDescriptorsResponse\x12\x45\n\x14resource_descriptors\x18\x01 \x03(\x0b\x32\'.google.api.MonitoredResourceDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t2\xe1\x04\n\x10LoggingServiceV2\x12w\n\tDeleteLog\x12#.google.logging.v2.DeleteLogRequest\x1a\x16.google.protobuf.Empty\"-\x82\xd3\xe4\x93\x02\'*%/v2beta1/{log_name=projects/*/logs/*}\x12\x86\x01\n\x0fWriteLogEntries\x12).google.logging.v2.WriteLogEntriesRequest\x1a*.google.logging.v2.WriteLogEntriesResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v2/entries:write:\x01*\x12\x82\x01\n\x0eListLogEntries\x12(.google.logging.v2.ListLogEntriesRequest\x1a).google.logging.v2.ListLogEntriesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v2/entries:list:\x01*\x12\xc5\x01\n ListMonitoredResourceDescriptors\x12:.google.logging.v2.ListMonitoredResourceDescriptorsRequest\x1a;.google.logging.v2.ListMonitoredResourceDescriptorsResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v2/monitoredResourceDescriptorsB*\n\x15\x63om.google.logging.v2B\x0cLoggingProtoP\x01\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n*google/cloud/grpc/logging/v2/logging.proto\x12\x11google.logging.v2\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a,google/cloud/grpc/logging/v2/log_entry.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\"$\n\x10\x44\x65leteLogRequest\x12\x10\n\x08log_name\x18\x01 \x01(\t\"\x98\x02\n\x16WriteLogEntriesRequest\x12\x10\n\x08log_name\x18\x01 \x01(\t\x12/\n\x08resource\x18\x02 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12\x45\n\x06labels\x18\x03 \x03(\x0b\x32\x35.google.logging.v2.WriteLogEntriesRequest.LabelsEntry\x12,\n\x07\x65ntries\x18\x04 \x03(\x0b\x32\x1b.google.logging.v2.LogEntry\x12\x17\n\x0fpartial_success\x18\x05 \x01(\x08\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x19\n\x17WriteLogEntriesResponse\"\x8d\x01\n\x15ListLogEntriesRequest\x12\x13\n\x0bproject_ids\x18\x01 \x03(\t\x12\x16\n\x0eresource_names\x18\x08 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x10\n\x08order_by\x18\x03 \x01(\t\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"_\n\x16ListLogEntriesResponse\x12,\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x1b.google.logging.v2.LogEntry\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"P\n\'ListMonitoredResourceDescriptorsRequest\x12\x11\n\tpage_size\x18\x01 \x01(\x05\x12\x12\n\npage_token\x18\x02 \x01(\t\"\x8a\x01\n(ListMonitoredResourceDescriptorsResponse\x12\x45\n\x14resource_descriptors\x18\x01 \x03(\x0b\x32\'.google.api.MonitoredResourceDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t2\xe1\x04\n\x10LoggingServiceV2\x12w\n\tDeleteLog\x12#.google.logging.v2.DeleteLogRequest\x1a\x16.google.protobuf.Empty\"-\x82\xd3\xe4\x93\x02\'*%/v2beta1/{log_name=projects/*/logs/*}\x12\x86\x01\n\x0fWriteLogEntries\x12).google.logging.v2.WriteLogEntriesRequest\x1a*.google.logging.v2.WriteLogEntriesResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v2/entries:write:\x01*\x12\x82\x01\n\x0eListLogEntries\x12(.google.logging.v2.ListLogEntriesRequest\x1a).google.logging.v2.ListLogEntriesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v2/entries:list:\x01*\x12\xc5\x01\n ListMonitoredResourceDescriptors\x12:.google.logging.v2.ListMonitoredResourceDescriptorsRequest\x1a;.google.logging.v2.ListMonitoredResourceDescriptorsResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v2/monitoredResourceDescriptorsB~\n\x15\x63om.google.logging.v2B\x0cLoggingProtoP\x01Z8google.golang.org/genproto/googleapis/logging/v2;logging\xf8\x01\x01\xaa\x02\x17Google.Cloud.Logging.V2b\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_api_dot_monitored__resource__pb2.DESCRIPTOR,google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_log__entry__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_rpc_dot_status__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -437,229 +437,234 @@ _sym_db.RegisterMessage(ListMonitoredResourceDescriptorsResponse)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\014LoggingProtoP\001\370\001\001'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\025com.google.logging.v2B\014LoggingProtoP\001Z8google.golang.org/genproto/googleapis/logging/v2;logging\370\001\001\252\002\027Google.Cloud.Logging.V2'))
 _WRITELOGENTRIESREQUEST_LABELSENTRY.has_options = True
 _WRITELOGENTRIESREQUEST_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-import grpc
-from grpc.beta import implementations as beta_implementations
-from grpc.beta import interfaces as beta_interfaces
-from grpc.framework.common import cardinality
-from grpc.framework.interfaces.face import utilities as face_utilities
+try:
+  # THESE ELEMENTS WILL BE DEPRECATED.
+  # Please use the generated *_pb2_grpc.py files instead.
+  import grpc
+  from grpc.framework.common import cardinality
+  from grpc.framework.interfaces.face import utilities as face_utilities
+  from grpc.beta import implementations as beta_implementations
+  from grpc.beta import interfaces as beta_interfaces
 
 
-class LoggingServiceV2Stub(object):
-  """Service for ingesting and querying logs.
-  """
-
-  def __init__(self, channel):
-    """Constructor.
-
-    Args:
-      channel: A grpc.Channel.
+  class LoggingServiceV2Stub(object):
+    """Service for ingesting and querying logs.
     """
-    self.DeleteLog = channel.unary_unary(
-        '/google.logging.v2.LoggingServiceV2/DeleteLog',
-        request_serializer=DeleteLogRequest.SerializeToString,
-        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-        )
-    self.WriteLogEntries = channel.unary_unary(
-        '/google.logging.v2.LoggingServiceV2/WriteLogEntries',
-        request_serializer=WriteLogEntriesRequest.SerializeToString,
-        response_deserializer=WriteLogEntriesResponse.FromString,
-        )
-    self.ListLogEntries = channel.unary_unary(
-        '/google.logging.v2.LoggingServiceV2/ListLogEntries',
-        request_serializer=ListLogEntriesRequest.SerializeToString,
-        response_deserializer=ListLogEntriesResponse.FromString,
-        )
-    self.ListMonitoredResourceDescriptors = channel.unary_unary(
-        '/google.logging.v2.LoggingServiceV2/ListMonitoredResourceDescriptors',
-        request_serializer=ListMonitoredResourceDescriptorsRequest.SerializeToString,
-        response_deserializer=ListMonitoredResourceDescriptorsResponse.FromString,
-        )
+
+    def __init__(self, channel):
+      """Constructor.
+
+      Args:
+        channel: A grpc.Channel.
+      """
+      self.DeleteLog = channel.unary_unary(
+          '/google.logging.v2.LoggingServiceV2/DeleteLog',
+          request_serializer=DeleteLogRequest.SerializeToString,
+          response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+          )
+      self.WriteLogEntries = channel.unary_unary(
+          '/google.logging.v2.LoggingServiceV2/WriteLogEntries',
+          request_serializer=WriteLogEntriesRequest.SerializeToString,
+          response_deserializer=WriteLogEntriesResponse.FromString,
+          )
+      self.ListLogEntries = channel.unary_unary(
+          '/google.logging.v2.LoggingServiceV2/ListLogEntries',
+          request_serializer=ListLogEntriesRequest.SerializeToString,
+          response_deserializer=ListLogEntriesResponse.FromString,
+          )
+      self.ListMonitoredResourceDescriptors = channel.unary_unary(
+          '/google.logging.v2.LoggingServiceV2/ListMonitoredResourceDescriptors',
+          request_serializer=ListMonitoredResourceDescriptorsRequest.SerializeToString,
+          response_deserializer=ListMonitoredResourceDescriptorsResponse.FromString,
+          )
 
 
-class LoggingServiceV2Servicer(object):
-  """Service for ingesting and querying logs.
-  """
-
-  def DeleteLog(self, request, context):
-    """Deletes all the log entries in a log.
-    The log reappears if it receives new entries.
+  class LoggingServiceV2Servicer(object):
+    """Service for ingesting and querying logs.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
 
-  def WriteLogEntries(self, request, context):
-    """Writes log entries to Stackdriver Logging.  All log entries are
-    written by this method.
+    def DeleteLog(self, request, context):
+      """Deletes all the log entries in a log.
+      The log reappears if it receives new entries.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def WriteLogEntries(self, request, context):
+      """Writes log entries to Stackdriver Logging.  All log entries are
+      written by this method.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def ListLogEntries(self, request, context):
+      """Lists log entries.  Use this method to retrieve log entries from Cloud
+      Logging.  For ways to export log entries, see
+      [Exporting Logs](/logging/docs/export).
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+    def ListMonitoredResourceDescriptors(self, request, context):
+      """Lists the monitored resource descriptors used by Stackdriver Logging.
+      """
+      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+      context.set_details('Method not implemented!')
+      raise NotImplementedError('Method not implemented!')
+
+
+  def add_LoggingServiceV2Servicer_to_server(servicer, server):
+    rpc_method_handlers = {
+        'DeleteLog': grpc.unary_unary_rpc_method_handler(
+            servicer.DeleteLog,
+            request_deserializer=DeleteLogRequest.FromString,
+            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+        ),
+        'WriteLogEntries': grpc.unary_unary_rpc_method_handler(
+            servicer.WriteLogEntries,
+            request_deserializer=WriteLogEntriesRequest.FromString,
+            response_serializer=WriteLogEntriesResponse.SerializeToString,
+        ),
+        'ListLogEntries': grpc.unary_unary_rpc_method_handler(
+            servicer.ListLogEntries,
+            request_deserializer=ListLogEntriesRequest.FromString,
+            response_serializer=ListLogEntriesResponse.SerializeToString,
+        ),
+        'ListMonitoredResourceDescriptors': grpc.unary_unary_rpc_method_handler(
+            servicer.ListMonitoredResourceDescriptors,
+            request_deserializer=ListMonitoredResourceDescriptorsRequest.FromString,
+            response_serializer=ListMonitoredResourceDescriptorsResponse.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        'google.logging.v2.LoggingServiceV2', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+
+
+  class BetaLoggingServiceV2Servicer(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for ingesting and querying logs.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
+    def DeleteLog(self, request, context):
+      """Deletes all the log entries in a log.
+      The log reappears if it receives new entries.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def WriteLogEntries(self, request, context):
+      """Writes log entries to Stackdriver Logging.  All log entries are
+      written by this method.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def ListLogEntries(self, request, context):
+      """Lists log entries.  Use this method to retrieve log entries from Cloud
+      Logging.  For ways to export log entries, see
+      [Exporting Logs](/logging/docs/export).
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    def ListMonitoredResourceDescriptors(self, request, context):
+      """Lists the monitored resource descriptors used by Stackdriver Logging.
+      """
+      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
-  def ListLogEntries(self, request, context):
-    """Lists log entries.  Use this method to retrieve log entries from Cloud
-    Logging.  For ways to export log entries, see
-    [Exporting Logs](/logging/docs/export).
+
+  class BetaLoggingServiceV2Stub(object):
+    """The Beta API is deprecated for 0.15.0 and later.
+
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This class was generated
+    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
+    """Service for ingesting and querying logs.
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def ListMonitoredResourceDescriptors(self, request, context):
-    """Lists the monitored resource descriptors used by Stackdriver Logging.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-
-def add_LoggingServiceV2Servicer_to_server(servicer, server):
-  rpc_method_handlers = {
-      'DeleteLog': grpc.unary_unary_rpc_method_handler(
-          servicer.DeleteLog,
-          request_deserializer=DeleteLogRequest.FromString,
-          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-      ),
-      'WriteLogEntries': grpc.unary_unary_rpc_method_handler(
-          servicer.WriteLogEntries,
-          request_deserializer=WriteLogEntriesRequest.FromString,
-          response_serializer=WriteLogEntriesResponse.SerializeToString,
-      ),
-      'ListLogEntries': grpc.unary_unary_rpc_method_handler(
-          servicer.ListLogEntries,
-          request_deserializer=ListLogEntriesRequest.FromString,
-          response_serializer=ListLogEntriesResponse.SerializeToString,
-      ),
-      'ListMonitoredResourceDescriptors': grpc.unary_unary_rpc_method_handler(
-          servicer.ListMonitoredResourceDescriptors,
-          request_deserializer=ListMonitoredResourceDescriptorsRequest.FromString,
-          response_serializer=ListMonitoredResourceDescriptorsResponse.SerializeToString,
-      ),
-  }
-  generic_handler = grpc.method_handlers_generic_handler(
-      'google.logging.v2.LoggingServiceV2', rpc_method_handlers)
-  server.add_generic_rpc_handlers((generic_handler,))
+    def DeleteLog(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Deletes all the log entries in a log.
+      The log reappears if it receives new entries.
+      """
+      raise NotImplementedError()
+    DeleteLog.future = None
+    def WriteLogEntries(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Writes log entries to Stackdriver Logging.  All log entries are
+      written by this method.
+      """
+      raise NotImplementedError()
+    WriteLogEntries.future = None
+    def ListLogEntries(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Lists log entries.  Use this method to retrieve log entries from Cloud
+      Logging.  For ways to export log entries, see
+      [Exporting Logs](/logging/docs/export).
+      """
+      raise NotImplementedError()
+    ListLogEntries.future = None
+    def ListMonitoredResourceDescriptors(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+      """Lists the monitored resource descriptors used by Stackdriver Logging.
+      """
+      raise NotImplementedError()
+    ListMonitoredResourceDescriptors.future = None
 
 
-class BetaLoggingServiceV2Servicer(object):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_LoggingServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for ingesting and querying logs.
-  """
-  def DeleteLog(self, request, context):
-    """Deletes all the log entries in a log.
-    The log reappears if it receives new entries.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def WriteLogEntries(self, request, context):
-    """Writes log entries to Stackdriver Logging.  All log entries are
-    written by this method.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def ListLogEntries(self, request, context):
-    """Lists log entries.  Use this method to retrieve log entries from Cloud
-    Logging.  For ways to export log entries, see
-    [Exporting Logs](/logging/docs/export).
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-  def ListMonitoredResourceDescriptors(self, request, context):
-    """Lists the monitored resource descriptors used by Stackdriver Logging.
-    """
-    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_deserializers = {
+      ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): DeleteLogRequest.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesRequest.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsRequest.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesRequest.FromString,
+    }
+    response_serializers = {
+      ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesResponse.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsResponse.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesResponse.SerializeToString,
+    }
+    method_implementations = {
+      ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): face_utilities.unary_unary_inline(servicer.DeleteLog),
+      ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): face_utilities.unary_unary_inline(servicer.ListLogEntries),
+      ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): face_utilities.unary_unary_inline(servicer.ListMonitoredResourceDescriptors),
+      ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): face_utilities.unary_unary_inline(servicer.WriteLogEntries),
+    }
+    server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
+    return beta_implementations.server(method_implementations, options=server_options)
 
 
-class BetaLoggingServiceV2Stub(object):
-  """The Beta API is deprecated for 0.15.0 and later.
+  def beta_create_LoggingServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
+    """The Beta API is deprecated for 0.15.0 and later.
 
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This class was generated
-  only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-  """Service for ingesting and querying logs.
-  """
-  def DeleteLog(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Deletes all the log entries in a log.
-    The log reappears if it receives new entries.
-    """
-    raise NotImplementedError()
-  DeleteLog.future = None
-  def WriteLogEntries(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Writes log entries to Stackdriver Logging.  All log entries are
-    written by this method.
-    """
-    raise NotImplementedError()
-  WriteLogEntries.future = None
-  def ListLogEntries(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Lists log entries.  Use this method to retrieve log entries from Cloud
-    Logging.  For ways to export log entries, see
-    [Exporting Logs](/logging/docs/export).
-    """
-    raise NotImplementedError()
-  ListLogEntries.future = None
-  def ListMonitoredResourceDescriptors(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-    """Lists the monitored resource descriptors used by Stackdriver Logging.
-    """
-    raise NotImplementedError()
-  ListMonitoredResourceDescriptors.future = None
-
-
-def beta_create_LoggingServiceV2_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_deserializers = {
-    ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): DeleteLogRequest.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesRequest.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsRequest.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesRequest.FromString,
-  }
-  response_serializers = {
-    ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesResponse.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsResponse.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesResponse.SerializeToString,
-  }
-  method_implementations = {
-    ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): face_utilities.unary_unary_inline(servicer.DeleteLog),
-    ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): face_utilities.unary_unary_inline(servicer.ListLogEntries),
-    ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): face_utilities.unary_unary_inline(servicer.ListMonitoredResourceDescriptors),
-    ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): face_utilities.unary_unary_inline(servicer.WriteLogEntries),
-  }
-  server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
-  return beta_implementations.server(method_implementations, options=server_options)
-
-
-def beta_create_LoggingServiceV2_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  """The Beta API is deprecated for 0.15.0 and later.
-
-  It is recommended to use the GA API (classes and functions in this
-  file not marked beta) for all further purposes. This function was
-  generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-  request_serializers = {
-    ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): DeleteLogRequest.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesRequest.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsRequest.SerializeToString,
-    ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesRequest.SerializeToString,
-  }
-  response_deserializers = {
-    ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesResponse.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsResponse.FromString,
-    ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesResponse.FromString,
-  }
-  cardinalities = {
-    'DeleteLog': cardinality.Cardinality.UNARY_UNARY,
-    'ListLogEntries': cardinality.Cardinality.UNARY_UNARY,
-    'ListMonitoredResourceDescriptors': cardinality.Cardinality.UNARY_UNARY,
-    'WriteLogEntries': cardinality.Cardinality.UNARY_UNARY,
-  }
-  stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
-  return beta_implementations.dynamic_stub(channel, 'google.logging.v2.LoggingServiceV2', cardinalities, options=stub_options)
+    It is recommended to use the GA API (classes and functions in this
+    file not marked beta) for all further purposes. This function was
+    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
+    request_serializers = {
+      ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): DeleteLogRequest.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesRequest.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsRequest.SerializeToString,
+      ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesRequest.SerializeToString,
+    }
+    response_deserializers = {
+      ('google.logging.v2.LoggingServiceV2', 'DeleteLog'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'ListLogEntries'): ListLogEntriesResponse.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'ListMonitoredResourceDescriptors'): ListMonitoredResourceDescriptorsResponse.FromString,
+      ('google.logging.v2.LoggingServiceV2', 'WriteLogEntries'): WriteLogEntriesResponse.FromString,
+    }
+    cardinalities = {
+      'DeleteLog': cardinality.Cardinality.UNARY_UNARY,
+      'ListLogEntries': cardinality.Cardinality.UNARY_UNARY,
+      'ListMonitoredResourceDescriptors': cardinality.Cardinality.UNARY_UNARY,
+      'WriteLogEntries': cardinality.Cardinality.UNARY_UNARY,
+    }
+    stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
+    return beta_implementations.dynamic_stub(channel, 'google.logging.v2.LoggingServiceV2', cardinalities, options=stub_options)
+except ImportError:
+  pass
 # @@protoc_insertion_point(module_scope)

--- a/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_pb2_grpc.py
+++ b/generated/python/grpc-google-cloud-logging-v2/google/cloud/grpc/logging/v2/logging_pb2_grpc.py
@@ -1,0 +1,109 @@
+import grpc
+from grpc.framework.common import cardinality
+from grpc.framework.interfaces.face import utilities as face_utilities
+
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.protobuf.empty_pb2 as google_dot_protobuf_dot_empty__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+import google.cloud.grpc.logging.v2.logging_pb2 as google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2
+
+
+class LoggingServiceV2Stub(object):
+  """Service for ingesting and querying logs.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.DeleteLog = channel.unary_unary(
+        '/google.logging.v2.LoggingServiceV2/DeleteLog',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.DeleteLogRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+    self.WriteLogEntries = channel.unary_unary(
+        '/google.logging.v2.LoggingServiceV2/WriteLogEntries',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.WriteLogEntriesRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.WriteLogEntriesResponse.FromString,
+        )
+    self.ListLogEntries = channel.unary_unary(
+        '/google.logging.v2.LoggingServiceV2/ListLogEntries',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListLogEntriesRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListLogEntriesResponse.FromString,
+        )
+    self.ListMonitoredResourceDescriptors = channel.unary_unary(
+        '/google.logging.v2.LoggingServiceV2/ListMonitoredResourceDescriptors',
+        request_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListMonitoredResourceDescriptorsRequest.SerializeToString,
+        response_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListMonitoredResourceDescriptorsResponse.FromString,
+        )
+
+
+class LoggingServiceV2Servicer(object):
+  """Service for ingesting and querying logs.
+  """
+
+  def DeleteLog(self, request, context):
+    """Deletes all the log entries in a log.
+    The log reappears if it receives new entries.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def WriteLogEntries(self, request, context):
+    """Writes log entries to Stackdriver Logging.  All log entries are
+    written by this method.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListLogEntries(self, request, context):
+    """Lists log entries.  Use this method to retrieve log entries from Cloud
+    Logging.  For ways to export log entries, see
+    [Exporting Logs](/logging/docs/export).
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListMonitoredResourceDescriptors(self, request, context):
+    """Lists the monitored resource descriptors used by Stackdriver Logging.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_LoggingServiceV2Servicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'DeleteLog': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteLog,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.DeleteLogRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+      'WriteLogEntries': grpc.unary_unary_rpc_method_handler(
+          servicer.WriteLogEntries,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.WriteLogEntriesRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.WriteLogEntriesResponse.SerializeToString,
+      ),
+      'ListLogEntries': grpc.unary_unary_rpc_method_handler(
+          servicer.ListLogEntries,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListLogEntriesRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListLogEntriesResponse.SerializeToString,
+      ),
+      'ListMonitoredResourceDescriptors': grpc.unary_unary_rpc_method_handler(
+          servicer.ListMonitoredResourceDescriptors,
+          request_deserializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListMonitoredResourceDescriptorsRequest.FromString,
+          response_serializer=google_dot_cloud_dot_grpc_dot_logging_dot_v2_dot_logging__pb2.ListMonitoredResourceDescriptorsResponse.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.logging.v2.LoggingServiceV2', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))

--- a/generated/python/grpc-google-cloud-logging-v2/setup.py
+++ b/generated/python/grpc-google-cloud-logging-v2/setup.py
@@ -1,4 +1,4 @@
-"""A setup module for the GRPC google-logging service.
+"""A setup module for the GRPC Stackdriver Logging service.
 
 See:
 https://packaging.python.org/en/latest/distributing.html
@@ -11,18 +11,18 @@ from setuptools import setup, find_packages
 
 install_requires = [
   'oauth2client>=2.0.0, <4.0dev',
-  'grpcio>=1.0.0, <2.0dev',
+  'grpcio>=1.0.2rc0, <2.0dev',
   'googleapis-common-protos[grpc]>=1.5.0, <2.0dev'
 ]
 
 setuptools.setup(
   name='grpc-google-cloud-logging-v2',
-  version='0.14.0',
+  version='0.90.0',
   author='Google Inc',
   author_email='googleapis-packages@google.com',
   classifiers=[
     'Intended Audience :: Developers',
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python',


### PR DESCRIPTION
@geigerj @dhermes This has the GAPIC config changes from @michaelbausor (https://github.com/googleapis/googleapis/pull/208). It is also built with the latest `grpcio 1.0.2rc0`, which wraps the gRPC code in `try-except`.

I believe this is ready for Beta. PTAL