### PR TITLE
Regenerated GAPIC for Pubsub (0.15.1).

### DIFF
--- a/generated/python/gapic-google-cloud-pubsub-v1/docs/conf.py
+++ b/generated/python/gapic-google-cloud-pubsub-v1/docs/conf.py
@@ -20,7 +20,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.15.0'
+__version__ = '0.15.1'
 
 # -- General configuration ------------------------------------------------
 
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'gapic-google-cloud-pubsub-v1'
-copyright = u'2016, Google'
+copyright = u'2017, Google'
 author = u'Google APIs'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/generated/python/gapic-google-cloud-pubsub-v1/docs/index.rst
+++ b/generated/python/gapic-google-cloud-pubsub-v1/docs/index.rst
@@ -11,7 +11,7 @@ easy-to-use client library for the `Google Cloud Pub/Sub API`_ (v1) defined in t
 
 
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/google/pubsub/v1
+.. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/pubsub/v1
 .. _`Google Cloud Pub/Sub API`: https://developers.google.com/apis-explorer/?hl=en_US#p/pubsub/v1/
 
 

--- a/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/publisher_client.py
+++ b/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/publisher_client.py
@@ -138,9 +138,9 @@ class PublisherClient(object):
                  scopes=None,
                  client_config=None,
                  app_name=None,
-                 app_version='UNKNOWN',
+                 app_version='',
                  lib_name=None,
-                 lib_version='UNKNOWN',
+                 lib_version='',
                  metrics_headers=()):
         """Constructor.
 

--- a/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/publisher_client_config.json
+++ b/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/publisher_client_config.json
@@ -2,17 +2,15 @@
   "interfaces": {
     "google.pubsub.v1.Publisher": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "one_plus_delivery": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "one_plus_delivery": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/subscriber_client_config.json
+++ b/generated/python/gapic-google-cloud-pubsub-v1/google/cloud/gapic/pubsub/v1/subscriber_client_config.json
@@ -2,13 +2,11 @@
   "interfaces": {
     "google.pubsub.v1.Subscriber": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {
@@ -37,6 +35,11 @@
           "retry_params_name": "default"
         },
         "GetSubscription": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateSubscription": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
@@ -72,6 +75,26 @@
           "retry_params_name": "messaging"
         },
         "ModifyPushConfig": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ListSnapshots": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateSnapshot": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteSnapshot": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Seek": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"

--- a/generated/python/gapic-google-cloud-pubsub-v1/requirements.txt
+++ b/generated/python/gapic-google-cloud-pubsub-v1/requirements.txt
@@ -1,5 +1,5 @@
 googleapis-common-protos>=1.5.2, <2.0dev
 grpc-google-iam-v1>=0.11.1, <0.12dev
 google-gax>=0.15.6, <0.16dev
-proto-google-cloud-pubsub-v1>=0.15.0, <0.16dev
+proto-google-cloud-pubsub-v1>=0.15.1, <0.16dev
 oauth2client>=2.0.0, <4.0dev

--- a/generated/python/gapic-google-cloud-pubsub-v1/setup.py
+++ b/generated/python/gapic-google-cloud-pubsub-v1/setup.py
@@ -12,13 +12,13 @@ install_requires = [
     'googleapis-common-protos>=1.5.2, <2.0dev',
     'grpc-google-iam-v1>=0.11.1, <0.12dev',
     'google-gax>=0.15.6, <0.16dev',
-    'proto-google-cloud-pubsub-v1>=0.15.0, <0.16dev',
+    'proto-google-cloud-pubsub-v1>=0.15.1, <0.16dev',
     'oauth2client>=2.0.0, <4.0dev',
 ]
 
 setup(
     name='gapic-google-cloud-pubsub-v1',
-    version='0.15.0',
+    version='0.15.1',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[


### PR DESCRIPTION
This is the regenerated GAPIC for PubSub with the new methods defined in the proto.

This does **not** fix the issue in googleapis/toolkit#1061, which will require another regen. I assert that this is fine.