### PR TITLE
Regenerate spanner clients.

### DIFF
--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/package.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/package.json
@@ -1,0 +1,27 @@
+{
+  "url": "https://github.com/googleapis/googleapis",
+  "name": "@google-cloud/spanner",
+  "version": "0.7.1",
+  "author": "Google Inc",
+  "description": "Cloud Spanner Database Admin API client for Node.js",
+  "main": "src/index.js",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "google-proto-files": "^0.10.0",
+    "google-gax": "^0.12.3",
+    "extend": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.12.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports.v1 = require('./v1');

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/database_admin_client.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/database_admin_client.js
@@ -1,0 +1,910 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * EDITING INSTRUCTIONS
+ * This file was generated from the file
+ * https://github.com/googleapis/googleapis/blob/master/google/spanner/admin/database/v1/spanner_database_admin.proto,
+ * and updates to that file get reflected here through a refresh process.
+ * For the short term, the refresh process will only be runnable by Google
+ * engineers.
+ *
+ * The only allowed edits are to method and file documentation. A 3-way
+ * merge preserves those additions if the generated source changes.
+ */
+/* TODO: introduce line-wrapping so that it never exceeds the limit. */
+/* jscs: disable maximumLineLength */
+'use strict';
+
+var configData = require('./database_admin_client_config');
+var extend = require('extend');
+var gax = require('google-gax');
+
+var SERVICE_ADDRESS = 'spanner.googleapis.com';
+
+var DEFAULT_SERVICE_PORT = 443;
+
+var CODE_GEN_NAME_VERSION = 'gapic/0.7.1';
+
+var PAGE_DESCRIPTORS = {
+  listDatabases: new gax.PageDescriptor(
+      'pageToken',
+      'nextPageToken',
+      'databases')
+};
+
+/**
+ * The scopes needed to make gRPC calls to all of the methods defined in
+ * this service.
+ */
+var ALL_SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/spanner.admin'
+];
+
+/**
+ * Cloud Spanner Database Admin API
+ *
+ * The Cloud Spanner Database Admin API can be used to create, drop, and
+ * list databases. It also enables updating the schema of pre-existing
+ * databases.
+ *
+ * This will be created through a builder function which can be obtained by the module.
+ * See the following example of how to initialize the module and how to access to the builder.
+ * @see {@link databaseAdminClient}
+ *
+ * @example
+ * var spannerV1 = require('@google-cloud/spanner').v1({
+ *   // optional auth parameters.
+ * });
+ * var client = spannerV1.databaseAdminClient();
+ *
+ * @class
+ */
+function DatabaseAdminClient(gaxGrpc, grpcClients, opts) {
+  opts = extend({
+    servicePath: SERVICE_ADDRESS,
+    port: DEFAULT_SERVICE_PORT,
+    clientConfig: {}
+  }, opts);
+
+  var googleApiClient = [
+    'gl-node/' + process.versions.node
+  ];
+  if (opts.libName && opts.libVersion) {
+    googleApiClient.push(opts.libName + '/' + opts.libVersion);
+  }
+  googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
+    'grpc/' + gaxGrpc.grpcVersion
+  );
+
+
+  this.operationsClient = new gax.lro({
+    auth: gaxGrpc.auth,
+    grpc: gaxGrpc.grpc
+  }).operationsClient(opts);
+
+  this.longrunningDescriptors = {
+    createDatabase: new gax.LongrunningDescriptor(
+      this.operationsClient,
+      grpcClients.google.spanner.admin.database.v1.Database.decode,
+      grpcClients.google.spanner.admin.database.v1.CreateDatabaseMetadata.decode),
+    updateDatabaseDdl: new gax.LongrunningDescriptor(
+      this.operationsClient,
+      grpcClients.google.protobuf.Empty.decode,
+      grpcClients.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata.decode)
+  };
+
+  var defaults = gaxGrpc.constructSettings(
+      'google.spanner.admin.database.v1.DatabaseAdmin',
+      configData,
+      opts.clientConfig,
+      {'x-goog-api-client': googleApiClient.join(' ')});
+
+  var self = this;
+
+  this.auth = gaxGrpc.auth;
+  var databaseAdminStub = gaxGrpc.createStub(
+      grpcClients.google.spanner.admin.database.v1.DatabaseAdmin,
+      opts);
+  var databaseAdminStubMethods = [
+    'listDatabases',
+    'createDatabase',
+    'getDatabase',
+    'updateDatabaseDdl',
+    'dropDatabase',
+    'getDatabaseDdl',
+    'setIamPolicy',
+    'getIamPolicy',
+    'testIamPermissions'
+  ];
+  databaseAdminStubMethods.forEach(function(methodName) {
+    self['_' + methodName] = gax.createApiCall(
+      databaseAdminStub.then(function(databaseAdminStub) {
+        return function() {
+          var args = Array.prototype.slice.call(arguments, 0);
+          return databaseAdminStub[methodName].apply(databaseAdminStub, args);
+        };
+      }),
+      defaults[methodName],
+      PAGE_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
+  });
+}
+
+// Path templates
+
+var INSTANCE_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instances/{instance}');
+
+var DATABASE_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instances/{instance}/databases/{database}');
+
+/**
+ * Returns a fully-qualified instance resource name string.
+ * @param {String} project
+ * @param {String} instance
+ * @returns {String}
+ */
+DatabaseAdminClient.prototype.instancePath = function(project, instance) {
+  return INSTANCE_PATH_TEMPLATE.render({
+    project: project,
+    instance: instance
+  });
+};
+
+/**
+ * Parses the instanceName from a instance resource.
+ * @param {String} instanceName
+ *   A fully-qualified path representing a instance resources.
+ * @returns {String} - A string representing the project.
+ */
+DatabaseAdminClient.prototype.matchProjectFromInstanceName = function(instanceName) {
+  return INSTANCE_PATH_TEMPLATE.match(instanceName).project;
+};
+
+/**
+ * Parses the instanceName from a instance resource.
+ * @param {String} instanceName
+ *   A fully-qualified path representing a instance resources.
+ * @returns {String} - A string representing the instance.
+ */
+DatabaseAdminClient.prototype.matchInstanceFromInstanceName = function(instanceName) {
+  return INSTANCE_PATH_TEMPLATE.match(instanceName).instance;
+};
+
+/**
+ * Returns a fully-qualified database resource name string.
+ * @param {String} project
+ * @param {String} instance
+ * @param {String} database
+ * @returns {String}
+ */
+DatabaseAdminClient.prototype.databasePath = function(project, instance, database) {
+  return DATABASE_PATH_TEMPLATE.render({
+    project: project,
+    instance: instance,
+    database: database
+  });
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the project.
+ */
+DatabaseAdminClient.prototype.matchProjectFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).project;
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the instance.
+ */
+DatabaseAdminClient.prototype.matchInstanceFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).instance;
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the database.
+ */
+DatabaseAdminClient.prototype.matchDatabaseFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).database;
+};
+
+/**
+ * Get the project ID used by this class.
+ * @aram {function(Error, string)} callback - the callback to be called with
+ *   the current project Id.
+ */
+DatabaseAdminClient.prototype.getProjectId = function(callback) {
+  return this.auth.getProjectId(callback);
+};
+
+// Service calls
+
+/**
+ * Lists Cloud Spanner databases.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The instance whose databases should be listed.
+ *   Values are of the form `projects/<project>/instances/<instance>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is Array of [Database]{@link Database}.
+ *
+ *   When autoPaginate: false is specified through options, it contains the result
+ *   in a single response. If the response indicates the next page exists, the third
+ *   parameter is set to be used for the next request object. The fourth parameter keeps
+ *   the raw response object of an object representing [ListDatabasesResponse]{@link ListDatabasesResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is Array of [Database]{@link Database}.
+ *
+ *   When autoPaginate: false is specified through options, the array has three elements.
+ *   The first element is Array of [Database]{@link Database} in a single response.
+ *   The second element is the next request object if the response
+ *   indicates the next page exists, or null. The third element is
+ *   an object representing [ListDatabasesResponse]{@link ListDatabasesResponse}.
+ *
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * // Iterate over all elements.
+ * client.listDatabases({parent: formattedParent}).then(function(responses) {
+ *     var resources = responses[0];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i])
+ *     }
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Or obtain the paged response.
+ * var options = {autoPaginate: false};
+ * function callback(responses) {
+ *     // The actual resources in a response.
+ *     var resources = responses[0];
+ *     // The next request if the response shows there's more responses.
+ *     var nextRequest = responses[1];
+ *     // The actual response object, if necessary.
+ *     // var rawResponse = responses[2];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i]);
+ *     }
+ *     if (nextRequest) {
+ *         // Fetch the next page.
+ *         return client.listDatabases(nextRequest, options).then(callback);
+ *     }
+ * }
+ * client.listDatabases({parent: formattedParent}, options)
+ *     .then(callback)
+ *     .catch(function(err) {
+ *         console.error(err);
+ *     });
+ */
+DatabaseAdminClient.prototype.listDatabases = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._listDatabases(request, options, callback);
+};
+
+/**
+ * Equivalent to {@link listDatabases}, but returns a NodeJS Stream object.
+ *
+ * This fetches the paged responses for {@link listDatabases} continuously
+ * and invokes the callback registered for 'data' event for each element in the
+ * responses.
+ *
+ * The returned object has 'end' method when no more elements are required.
+ *
+ * autoPaginate option will be ignored.
+ *
+ * @see {@link https://nodejs.org/api/stream.html}
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The instance whose databases should be listed.
+ *   Values are of the form `projects/<project>/instances/<instance>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @return {Stream}
+ *   An object stream which emits an object representing [Database]{@link Database} on 'data' event.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * client.listDatabasesStream({parent: formattedParent}).on('data', function(element) {
+ *     // doThingsWith(element)
+ * }).on('error', function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.listDatabasesStream = function(request, options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  return PAGE_DESCRIPTORS.listDatabases.createStream(this._listDatabases, request, options);
+};
+
+/**
+ * Creates a new Cloud Spanner database and starts to prepare it for serving.
+ * The returned {@link long-running operation} will
+ * have a name of the format `<database_name>/operations/<operation_id>` and
+ * can be used to track preparation of the database. The
+ * {@link metadata} field type is
+ * {@link CreateDatabaseMetadata}. The
+ * {@link response} field type is
+ * {@link Database}, if successful.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the instance that will serve the new database.
+ *   Values are of the form `projects/<project>/instances/<instance>`.
+ * @param {string} request.createStatement
+ *   Required. A `CREATE DATABASE` statement, which specifies the ID of the
+ *   new database.  The database ID must conform to the regular expression
+ *   `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
+ * @param {string[]=} request.extraStatements
+ *   An optional list of DDL statements to run inside the newly created
+ *   database. Statements can create tables, indexes, etc. These
+ *   statements execute atomically with the creation of the database:
+ *   if there is an error in any statement, the database is not created.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * var createStatement = '';
+ * var request = {
+ *     parent: formattedParent,
+ *     createStatement: createStatement
+ * };
+ *
+ * // Handle the operation using the promise pattern.
+ * client.createDatabase(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.createDatabase(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.createDatabase = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._createDatabase(request, options, callback);
+};
+
+/**
+ * Gets the state of a Cloud Spanner database.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the requested database. Values are of the form
+ *   `projects/<project>/instances/<instance>/databases/<database>`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Database]{@link Database}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Database]{@link Database}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedName = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * client.getDatabase({name: formattedName}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.getDatabase = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getDatabase(request, options, callback);
+};
+
+/**
+ * Updates the schema of a Cloud Spanner database by
+ * creating/altering/dropping tables, columns, indexes, etc. The returned
+ * {@link long-running operation} will have a name of
+ * the format `<database_name>/operations/<operation_id>` and can be used to
+ * track execution of the schema change(s). The
+ * {@link metadata} field type is
+ * {@link UpdateDatabaseDdlMetadata}.  The operation has no response.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.database
+ *   Required. The database to update.
+ * @param {string[]} request.statements
+ *   DDL statements to be applied to the database.
+ * @param {string=} request.operationId
+ *   If empty, the new update request is assigned an
+ *   automatically-generated operation ID. Otherwise, `operation_id`
+ *   is used to construct the name of the resulting
+ *   {@link Operation}.
+ *
+ *   Specifying an explicit operation ID simplifies determining
+ *   whether the statements were executed in the event that the
+ *   {@link UpdateDatabaseDdl} call is replayed,
+ *   or the return value is otherwise lost: the {@link database} and
+ *   `operation_id` fields can be combined to form the
+ *   {@link name} of the resulting
+ *   {@link longrunning.Operation}: `<database>/operations/<operation_id>`.
+ *
+ *   `operation_id` should be unique within the database, and must be
+ *   a valid identifier: `[a-z][a-z0-9_]*`. Note that
+ *   automatically-generated operation IDs always begin with an
+ *   underscore. If the named operation already exists,
+ *   {@link UpdateDatabaseDdl} returns
+ *   `ALREADY_EXISTS`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * var statements = [];
+ * var request = {
+ *     database: formattedDatabase,
+ *     statements: statements
+ * };
+ *
+ * // Handle the operation using the promise pattern.
+ * client.updateDatabaseDdl(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.updateDatabaseDdl(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.updateDatabaseDdl = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._updateDatabaseDdl(request, options, callback);
+};
+
+/**
+ * Drops (aka deletes) a Cloud Spanner database.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.database
+ *   Required. The database to be dropped.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error)=} callback
+ *   The function which will be called with the result of the API call.
+ * @return {Promise} - The promise which resolves when API call finishes.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * client.dropDatabase({database: formattedDatabase}).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.dropDatabase = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._dropDatabase(request, options, callback);
+};
+
+/**
+ * Returns the schema of a Cloud Spanner database as a list of formatted
+ * DDL statements. This method does not show pending schema updates, those may
+ * be queried using the {@link Operations} API.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.database
+ *   Required. The database whose schema we wish to get.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [GetDatabaseDdlResponse]{@link GetDatabaseDdlResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [GetDatabaseDdlResponse]{@link GetDatabaseDdlResponse}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * client.getDatabaseDdl({database: formattedDatabase}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.getDatabaseDdl = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getDatabaseDdl(request, options, callback);
+};
+
+/**
+ * Sets the access control policy on a database resource. Replaces any
+ * existing policy.
+ *
+ * Authorization requires `spanner.databases.setIamPolicy` permission on
+ * {@link resource}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy is being specified.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {Object} request.policy
+ *   REQUIRED: The complete policy to be applied to the `resource`. The size of
+ *   the policy is limited to a few 10s of KB. An empty policy is a
+ *   valid policy but certain Cloud Platform services (such as Projects)
+ *   might reject them.
+ *
+ *   This object should have the same structure as [Policy]{@link Policy}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Policy]{@link Policy}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Policy]{@link Policy}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * var policy = {};
+ * var request = {
+ *     resource: formattedResource,
+ *     policy: policy
+ * };
+ * client.setIamPolicy(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.setIamPolicy = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._setIamPolicy(request, options, callback);
+};
+
+/**
+ * Gets the access control policy for a database resource. Returns an empty
+ * policy if a database exists but does not have a policy set.
+ *
+ * Authorization requires `spanner.databases.getIamPolicy` permission on
+ * {@link resource}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy is being requested.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Policy]{@link Policy}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Policy]{@link Policy}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * client.getIamPolicy({resource: formattedResource}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.getIamPolicy = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getIamPolicy(request, options, callback);
+};
+
+/**
+ * Returns permissions that the caller has on the specified database resource.
+ *
+ * Attempting this RPC on a non-existent Cloud Spanner database will result in
+ * a NOT_FOUND error if the user has `spanner.databases.list` permission on
+ * the containing Cloud Spanner instance. Otherwise returns an empty set of
+ * permissions.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy detail is being requested.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {string[]} request.permissions
+ *   The set of permissions to check for the `resource`. Permissions with
+ *   wildcards (such as '*' or 'storage.*') are not allowed. For more
+ *   information see
+ *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [TestIamPermissionsResponse]{@link TestIamPermissionsResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [TestIamPermissionsResponse]{@link TestIamPermissionsResponse}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.databaseAdminClient();
+ * var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * var permissions = [];
+ * var request = {
+ *     resource: formattedResource,
+ *     permissions: permissions
+ * };
+ * client.testIamPermissions(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+DatabaseAdminClient.prototype.testIamPermissions = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._testIamPermissions(request, options, callback);
+};
+
+function DatabaseAdminClientBuilder(gaxGrpc) {
+  if (!(this instanceof DatabaseAdminClientBuilder)) {
+    return new DatabaseAdminClientBuilder(gaxGrpc);
+  }
+
+  var databaseAdminClient = gaxGrpc.load([{
+    root: require('google-proto-files')('..'),
+    file: 'google/spanner/admin/database/v1/spanner_database_admin.proto'
+  }]);
+  extend(this, databaseAdminClient.google.spanner.admin.database.v1);
+
+
+  /**
+   * Build a new instance of {@link DatabaseAdminClient}.
+   *
+   * @param {Object=} opts - The optional parameters.
+   * @param {String=} opts.servicePath
+   *   The domain name of the API remote host.
+   * @param {number=} opts.port
+   *   The port on which to connect to the remote host.
+   * @param {grpc.ClientCredentials=} opts.sslCreds
+   *   A ClientCredentials for use with an SSL-enabled channel.
+   * @param {Object=} opts.clientConfig
+   *   The customized config to build the call settings. See
+   *   {@link gax.constructSettings} for the format.
+   */
+  this.databaseAdminClient = function(opts) {
+    return new DatabaseAdminClient(gaxGrpc, databaseAdminClient, opts);
+  };
+  extend(this.databaseAdminClient, DatabaseAdminClient);
+}
+module.exports = DatabaseAdminClientBuilder;
+module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/database_admin_client_config.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/database_admin_client_config.json
@@ -1,0 +1,73 @@
+{
+  "interfaces": {
+    "google.spanner.admin.database.v1.DatabaseAdmin": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 1000,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 32000,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "ListDatabases": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateDatabase": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetDatabase": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateDatabaseDdl": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DropDatabase": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetDatabaseDdl": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "SetIamPolicy": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetIamPolicy": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "TestIamPermissions": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/src/v1/index.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var databaseAdminClient = require('./database_admin_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  return databaseAdminClient(gaxGrpc);
+}
+
+v1.SERVICE_ADDRESS = databaseAdminClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = databaseAdminClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-database/test/test.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-database/test/test.js
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var spannerV1 = require('../src/').v1();
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('DatabaseAdminClient', function() {
+  describe('listDatabases', function() {
+    it('invokes listDatabases without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var databasesElement = {};
+      var databases = [databasesElement];
+      var expectedResponse = {
+          nextPageToken : nextPageToken,
+          databases : databases
+      };
+
+      // Mock Grpc layer
+      client._listDatabases = function(actualRequest, options, callback) {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.databases);
+      };
+
+      client.listDatabases(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.databases);
+        done();
+      });
+    });
+
+    it('invokes listDatabases with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock Grpc layer
+      client._listDatabases = mockSimpleGrpcMethod(request, null, error);
+
+      client.listDatabases(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('createDatabase', function() {
+    it('invokes createDatabase without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var createStatement = 'createStatement552974828';
+      var request = {
+          parent : formattedParent,
+          createStatement : createStatement
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var expectedResponse = {
+          name : name
+      };
+
+      // Mock Grpc layer
+      client._createDatabase = mockLongRunningGrpcMethod(request, expectedResponse);
+
+      client.createDatabase(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.deepStrictEqual(responses[0], expectedResponse);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes createDatabase with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedParent = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var createStatement = 'createStatement552974828';
+      var request = {
+          parent : formattedParent,
+          createStatement : createStatement
+      };
+
+      // Mock Grpc layer
+      client._createDatabase = mockLongRunningGrpcMethod(request, null, error);
+
+      client.createDatabase(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.fail();
+      }).catch(function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getDatabase', function() {
+    it('invokes getDatabase without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedName = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var expectedResponse = {
+          name : name2
+      };
+
+      // Mock Grpc layer
+      client._getDatabase = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getDatabase(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getDatabase with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedName = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._getDatabase = mockSimpleGrpcMethod(request, null, error);
+
+      client.getDatabase(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('updateDatabaseDdl', function() {
+    it('invokes updateDatabaseDdl without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var statements = [];
+      var request = {
+          database : formattedDatabase,
+          statements : statements
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._updateDatabaseDdl = mockLongRunningGrpcMethod(request, expectedResponse);
+
+      client.updateDatabaseDdl(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.deepStrictEqual(responses[0], expectedResponse);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes updateDatabaseDdl with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var statements = [];
+      var request = {
+          database : formattedDatabase,
+          statements : statements
+      };
+
+      // Mock Grpc layer
+      client._updateDatabaseDdl = mockLongRunningGrpcMethod(request, null, error);
+
+      client.updateDatabaseDdl(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.fail();
+      }).catch(function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('dropDatabase', function() {
+    it('invokes dropDatabase without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock Grpc layer
+      client._dropDatabase = mockSimpleGrpcMethod(request);
+
+      client.dropDatabase(request, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes dropDatabase with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock Grpc layer
+      client._dropDatabase = mockSimpleGrpcMethod(request, null, error);
+
+      client.dropDatabase(request, function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getDatabaseDdl', function() {
+    it('invokes getDatabaseDdl without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._getDatabaseDdl = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getDatabaseDdl(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getDatabaseDdl with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock Grpc layer
+      client._getDatabaseDdl = mockSimpleGrpcMethod(request, null, error);
+
+      client.getDatabaseDdl(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('setIamPolicy', function() {
+    it('invokes setIamPolicy without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var policy = {};
+      var request = {
+          resource : formattedResource,
+          policy : policy
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+          version : version,
+          etag : etag
+      };
+
+      // Mock Grpc layer
+      client._setIamPolicy = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.setIamPolicy(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes setIamPolicy with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var policy = {};
+      var request = {
+          resource : formattedResource,
+          policy : policy
+      };
+
+      // Mock Grpc layer
+      client._setIamPolicy = mockSimpleGrpcMethod(request, null, error);
+
+      client.setIamPolicy(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getIamPolicy', function() {
+    it('invokes getIamPolicy without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          resource : formattedResource
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+          version : version,
+          etag : etag
+      };
+
+      // Mock Grpc layer
+      client._getIamPolicy = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getIamPolicy(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getIamPolicy with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          resource : formattedResource
+      };
+
+      // Mock Grpc layer
+      client._getIamPolicy = mockSimpleGrpcMethod(request, null, error);
+
+      client.getIamPolicy(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('testIamPermissions', function() {
+    it('invokes testIamPermissions without error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var permissions = [];
+      var request = {
+          resource : formattedResource,
+          permissions : permissions
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._testIamPermissions = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.testIamPermissions(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes testIamPermissions with error', function(done) {
+      var client = spannerV1.databaseAdminClient();
+      // Mock request
+      var formattedResource = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var permissions = [];
+      var request = {
+          resource : formattedResource,
+          permissions : permissions
+      };
+
+      // Mock Grpc layer
+      client._testIamPermissions = mockSimpleGrpcMethod(request, null, error);
+
+      client.testIamPermissions(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockLongRunningGrpcMethod(expectedRequest, response, error) {
+  return function(request) {
+    assert.deepStrictEqual(request, expectedRequest);
+    var mockOperation = {
+      promise: function() {
+        return new Promise(function(resolve, reject) {
+          if (error) {
+            reject(error)
+          } else {
+            resolve([response]);
+          }
+        });
+      }
+    };
+    return Promise.resolve([mockOperation]);
+  };
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/package.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/package.json
@@ -1,0 +1,27 @@
+{
+  "url": "https://github.com/googleapis/googleapis",
+  "name": "@google-cloud/spanner",
+  "version": "0.7.1",
+  "author": "Google Inc",
+  "description": "Cloud Spanner Instance Admin API client for Node.js",
+  "main": "src/index.js",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "google-proto-files": "^0.10.0",
+    "google-gax": "^0.12.3",
+    "extend": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.12.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports.v1 = require('./v1');

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/index.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var instanceAdminClient = require('./instance_admin_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  return instanceAdminClient(gaxGrpc);
+}
+
+v1.SERVICE_ADDRESS = instanceAdminClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = instanceAdminClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/instance_admin_client.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/instance_admin_client.js
@@ -1,0 +1,1178 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * EDITING INSTRUCTIONS
+ * This file was generated from the file
+ * https://github.com/googleapis/googleapis/blob/master/google/spanner/admin/instance/v1/spanner_instance_admin.proto,
+ * and updates to that file get reflected here through a refresh process.
+ * For the short term, the refresh process will only be runnable by Google
+ * engineers.
+ *
+ * The only allowed edits are to method and file documentation. A 3-way
+ * merge preserves those additions if the generated source changes.
+ */
+/* TODO: introduce line-wrapping so that it never exceeds the limit. */
+/* jscs: disable maximumLineLength */
+'use strict';
+
+var configData = require('./instance_admin_client_config');
+var extend = require('extend');
+var gax = require('google-gax');
+
+var SERVICE_ADDRESS = 'spanner.googleapis.com';
+
+var DEFAULT_SERVICE_PORT = 443;
+
+var CODE_GEN_NAME_VERSION = 'gapic/0.7.1';
+
+var PAGE_DESCRIPTORS = {
+  listInstanceConfigs: new gax.PageDescriptor(
+      'pageToken',
+      'nextPageToken',
+      'instanceConfigs'),
+  listInstances: new gax.PageDescriptor(
+      'pageToken',
+      'nextPageToken',
+      'instances')
+};
+
+/**
+ * The scopes needed to make gRPC calls to all of the methods defined in
+ * this service.
+ */
+var ALL_SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/spanner.admin'
+];
+
+/**
+ * Cloud Spanner Instance Admin API
+ *
+ * The Cloud Spanner Instance Admin API can be used to create, delete,
+ * modify and list instances. Instances are dedicated Cloud Spanner serving
+ * and storage resources to be used by Cloud Spanner databases.
+ *
+ * Each instance has a "configuration", which dictates where the
+ * serving resources for the Cloud Spanner instance are located (e.g.,
+ * US-central, Europe). Configurations are created by Google based on
+ * resource availability.
+ *
+ * Cloud Spanner billing is based on the instances that exist and their
+ * sizes. After an instance exists, there are no additional
+ * per-database or per-operation charges for use of the instance
+ * (though there may be additional network bandwidth charges).
+ * Instances offer isolation: problems with databases in one instance
+ * will not affect other instances. However, within an instance
+ * databases can affect each other. For example, if one database in an
+ * instance receives a lot of requests and consumes most of the
+ * instance resources, fewer resources are available for other
+ * databases in that instance, and their performance may suffer.
+ *
+ * This will be created through a builder function which can be obtained by the module.
+ * See the following example of how to initialize the module and how to access to the builder.
+ * @see {@link instanceAdminClient}
+ *
+ * @example
+ * var spannerV1 = require('@google-cloud/spanner').v1({
+ *   // optional auth parameters.
+ * });
+ * var client = spannerV1.instanceAdminClient();
+ *
+ * @class
+ */
+function InstanceAdminClient(gaxGrpc, grpcClients, opts) {
+  opts = extend({
+    servicePath: SERVICE_ADDRESS,
+    port: DEFAULT_SERVICE_PORT,
+    clientConfig: {}
+  }, opts);
+
+  var googleApiClient = [
+    'gl-node/' + process.versions.node
+  ];
+  if (opts.libName && opts.libVersion) {
+    googleApiClient.push(opts.libName + '/' + opts.libVersion);
+  }
+  googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
+    'grpc/' + gaxGrpc.grpcVersion
+  );
+
+
+  this.operationsClient = new gax.lro({
+    auth: gaxGrpc.auth,
+    grpc: gaxGrpc.grpc
+  }).operationsClient(opts);
+
+  this.longrunningDescriptors = {
+    createInstance: new gax.LongrunningDescriptor(
+      this.operationsClient,
+      grpcClients.google.spanner.admin.instance.v1.Instance.decode,
+      grpcClients.google.spanner.admin.instance.v1.CreateInstanceMetadata.decode),
+    updateInstance: new gax.LongrunningDescriptor(
+      this.operationsClient,
+      grpcClients.google.spanner.admin.instance.v1.Instance.decode,
+      grpcClients.google.spanner.admin.instance.v1.UpdateInstanceMetadata.decode)
+  };
+
+  var defaults = gaxGrpc.constructSettings(
+      'google.spanner.admin.instance.v1.InstanceAdmin',
+      configData,
+      opts.clientConfig,
+      {'x-goog-api-client': googleApiClient.join(' ')});
+
+  var self = this;
+
+  this.auth = gaxGrpc.auth;
+  var instanceAdminStub = gaxGrpc.createStub(
+      grpcClients.google.spanner.admin.instance.v1.InstanceAdmin,
+      opts);
+  var instanceAdminStubMethods = [
+    'listInstanceConfigs',
+    'getInstanceConfig',
+    'listInstances',
+    'getInstance',
+    'createInstance',
+    'updateInstance',
+    'deleteInstance',
+    'setIamPolicy',
+    'getIamPolicy',
+    'testIamPermissions'
+  ];
+  instanceAdminStubMethods.forEach(function(methodName) {
+    self['_' + methodName] = gax.createApiCall(
+      instanceAdminStub.then(function(instanceAdminStub) {
+        return function() {
+          var args = Array.prototype.slice.call(arguments, 0);
+          return instanceAdminStub[methodName].apply(instanceAdminStub, args);
+        };
+      }),
+      defaults[methodName],
+      PAGE_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
+  });
+}
+
+// Path templates
+
+var PROJECT_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}');
+
+var INSTANCE_CONFIG_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instanceConfigs/{instance_config}');
+
+var INSTANCE_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instances/{instance}');
+
+/**
+ * Returns a fully-qualified project resource name string.
+ * @param {String} project
+ * @returns {String}
+ */
+InstanceAdminClient.prototype.projectPath = function(project) {
+  return PROJECT_PATH_TEMPLATE.render({
+    project: project
+  });
+};
+
+/**
+ * Parses the projectName from a project resource.
+ * @param {String} projectName
+ *   A fully-qualified path representing a project resources.
+ * @returns {String} - A string representing the project.
+ */
+InstanceAdminClient.prototype.matchProjectFromProjectName = function(projectName) {
+  return PROJECT_PATH_TEMPLATE.match(projectName).project;
+};
+
+/**
+ * Returns a fully-qualified instance_config resource name string.
+ * @param {String} project
+ * @param {String} instanceConfig
+ * @returns {String}
+ */
+InstanceAdminClient.prototype.instanceConfigPath = function(project, instanceConfig) {
+  return INSTANCE_CONFIG_PATH_TEMPLATE.render({
+    project: project,
+    instance_config: instanceConfig
+  });
+};
+
+/**
+ * Parses the instanceConfigName from a instance_config resource.
+ * @param {String} instanceConfigName
+ *   A fully-qualified path representing a instance_config resources.
+ * @returns {String} - A string representing the project.
+ */
+InstanceAdminClient.prototype.matchProjectFromInstanceConfigName = function(instanceConfigName) {
+  return INSTANCE_CONFIG_PATH_TEMPLATE.match(instanceConfigName).project;
+};
+
+/**
+ * Parses the instanceConfigName from a instance_config resource.
+ * @param {String} instanceConfigName
+ *   A fully-qualified path representing a instance_config resources.
+ * @returns {String} - A string representing the instance_config.
+ */
+InstanceAdminClient.prototype.matchInstanceConfigFromInstanceConfigName = function(instanceConfigName) {
+  return INSTANCE_CONFIG_PATH_TEMPLATE.match(instanceConfigName).instance_config;
+};
+
+/**
+ * Returns a fully-qualified instance resource name string.
+ * @param {String} project
+ * @param {String} instance
+ * @returns {String}
+ */
+InstanceAdminClient.prototype.instancePath = function(project, instance) {
+  return INSTANCE_PATH_TEMPLATE.render({
+    project: project,
+    instance: instance
+  });
+};
+
+/**
+ * Parses the instanceName from a instance resource.
+ * @param {String} instanceName
+ *   A fully-qualified path representing a instance resources.
+ * @returns {String} - A string representing the project.
+ */
+InstanceAdminClient.prototype.matchProjectFromInstanceName = function(instanceName) {
+  return INSTANCE_PATH_TEMPLATE.match(instanceName).project;
+};
+
+/**
+ * Parses the instanceName from a instance resource.
+ * @param {String} instanceName
+ *   A fully-qualified path representing a instance resources.
+ * @returns {String} - A string representing the instance.
+ */
+InstanceAdminClient.prototype.matchInstanceFromInstanceName = function(instanceName) {
+  return INSTANCE_PATH_TEMPLATE.match(instanceName).instance;
+};
+
+/**
+ * Get the project ID used by this class.
+ * @aram {function(Error, string)} callback - the callback to be called with
+ *   the current project Id.
+ */
+InstanceAdminClient.prototype.getProjectId = function(callback) {
+  return this.auth.getProjectId(callback);
+};
+
+// Service calls
+
+/**
+ * Lists the supported instance configurations for a given project.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the project for which a list of supported instance
+ *   configurations is requested. Values are of the form
+ *   `projects/<project>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is Array of [InstanceConfig]{@link InstanceConfig}.
+ *
+ *   When autoPaginate: false is specified through options, it contains the result
+ *   in a single response. If the response indicates the next page exists, the third
+ *   parameter is set to be used for the next request object. The fourth parameter keeps
+ *   the raw response object of an object representing [ListInstanceConfigsResponse]{@link ListInstanceConfigsResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is Array of [InstanceConfig]{@link InstanceConfig}.
+ *
+ *   When autoPaginate: false is specified through options, the array has three elements.
+ *   The first element is Array of [InstanceConfig]{@link InstanceConfig} in a single response.
+ *   The second element is the next request object if the response
+ *   indicates the next page exists, or null. The third element is
+ *   an object representing [ListInstanceConfigsResponse]{@link ListInstanceConfigsResponse}.
+ *
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedParent = client.projectPath("[PROJECT]");
+ * // Iterate over all elements.
+ * client.listInstanceConfigs({parent: formattedParent}).then(function(responses) {
+ *     var resources = responses[0];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i])
+ *     }
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Or obtain the paged response.
+ * var options = {autoPaginate: false};
+ * function callback(responses) {
+ *     // The actual resources in a response.
+ *     var resources = responses[0];
+ *     // The next request if the response shows there's more responses.
+ *     var nextRequest = responses[1];
+ *     // The actual response object, if necessary.
+ *     // var rawResponse = responses[2];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i]);
+ *     }
+ *     if (nextRequest) {
+ *         // Fetch the next page.
+ *         return client.listInstanceConfigs(nextRequest, options).then(callback);
+ *     }
+ * }
+ * client.listInstanceConfigs({parent: formattedParent}, options)
+ *     .then(callback)
+ *     .catch(function(err) {
+ *         console.error(err);
+ *     });
+ */
+InstanceAdminClient.prototype.listInstanceConfigs = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._listInstanceConfigs(request, options, callback);
+};
+
+/**
+ * Equivalent to {@link listInstanceConfigs}, but returns a NodeJS Stream object.
+ *
+ * This fetches the paged responses for {@link listInstanceConfigs} continuously
+ * and invokes the callback registered for 'data' event for each element in the
+ * responses.
+ *
+ * The returned object has 'end' method when no more elements are required.
+ *
+ * autoPaginate option will be ignored.
+ *
+ * @see {@link https://nodejs.org/api/stream.html}
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the project for which a list of supported instance
+ *   configurations is requested. Values are of the form
+ *   `projects/<project>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @return {Stream}
+ *   An object stream which emits an object representing [InstanceConfig]{@link InstanceConfig} on 'data' event.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedParent = client.projectPath("[PROJECT]");
+ * client.listInstanceConfigsStream({parent: formattedParent}).on('data', function(element) {
+ *     // doThingsWith(element)
+ * }).on('error', function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.listInstanceConfigsStream = function(request, options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  return PAGE_DESCRIPTORS.listInstanceConfigs.createStream(this._listInstanceConfigs, request, options);
+};
+
+/**
+ * Gets information about a particular instance configuration.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the requested instance configuration. Values are of
+ *   the form `projects/<project>/instanceConfigs/<config>`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [InstanceConfig]{@link InstanceConfig}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [InstanceConfig]{@link InstanceConfig}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedName = client.instanceConfigPath("[PROJECT]", "[INSTANCE_CONFIG]");
+ * client.getInstanceConfig({name: formattedName}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.getInstanceConfig = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getInstanceConfig(request, options, callback);
+};
+
+/**
+ * Lists all instances in the given project.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the project for which a list of instances is
+ *   requested. Values are of the form `projects/<project>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {string=} request.filter
+ *   An expression for filtering the results of the request. Filter rules are
+ *   case insensitive. The fields eligible for filtering are:
+ *
+ *     * name
+ *     * display_name
+ *     * labels.key where key is the name of a label
+ *
+ *   Some examples of using filters are:
+ *
+ *     * name:* --> The instance has a name.
+ *     * name:Howl --> The instance's name contains the string "howl".
+ *     * name:HOWL --> Equivalent to above.
+ *     * NAME:howl --> Equivalent to above.
+ *     * labels.env:* --> The instance has the label "env".
+ *     * labels.env:dev --> The instance has the label "env" and the value of
+ *                          the label contains the string "dev".
+ *     * name:howl labels.env:dev --> The instance's name contains "howl" and
+ *                                    it has the label "env" with its value
+ *                                    containing "dev".
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is Array of [Instance]{@link Instance}.
+ *
+ *   When autoPaginate: false is specified through options, it contains the result
+ *   in a single response. If the response indicates the next page exists, the third
+ *   parameter is set to be used for the next request object. The fourth parameter keeps
+ *   the raw response object of an object representing [ListInstancesResponse]{@link ListInstancesResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is Array of [Instance]{@link Instance}.
+ *
+ *   When autoPaginate: false is specified through options, the array has three elements.
+ *   The first element is Array of [Instance]{@link Instance} in a single response.
+ *   The second element is the next request object if the response
+ *   indicates the next page exists, or null. The third element is
+ *   an object representing [ListInstancesResponse]{@link ListInstancesResponse}.
+ *
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedParent = client.projectPath("[PROJECT]");
+ * // Iterate over all elements.
+ * client.listInstances({parent: formattedParent}).then(function(responses) {
+ *     var resources = responses[0];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i])
+ *     }
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Or obtain the paged response.
+ * var options = {autoPaginate: false};
+ * function callback(responses) {
+ *     // The actual resources in a response.
+ *     var resources = responses[0];
+ *     // The next request if the response shows there's more responses.
+ *     var nextRequest = responses[1];
+ *     // The actual response object, if necessary.
+ *     // var rawResponse = responses[2];
+ *     for (var i = 0; i < resources.length; ++i) {
+ *         // doThingsWith(resources[i]);
+ *     }
+ *     if (nextRequest) {
+ *         // Fetch the next page.
+ *         return client.listInstances(nextRequest, options).then(callback);
+ *     }
+ * }
+ * client.listInstances({parent: formattedParent}, options)
+ *     .then(callback)
+ *     .catch(function(err) {
+ *         console.error(err);
+ *     });
+ */
+InstanceAdminClient.prototype.listInstances = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._listInstances(request, options, callback);
+};
+
+/**
+ * Equivalent to {@link listInstances}, but returns a NodeJS Stream object.
+ *
+ * This fetches the paged responses for {@link listInstances} continuously
+ * and invokes the callback registered for 'data' event for each element in the
+ * responses.
+ *
+ * The returned object has 'end' method when no more elements are required.
+ *
+ * autoPaginate option will be ignored.
+ *
+ * @see {@link https://nodejs.org/api/stream.html}
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the project for which a list of instances is
+ *   requested. Values are of the form `projects/<project>`.
+ * @param {number=} request.pageSize
+ *   The maximum number of resources contained in the underlying API
+ *   response. If page streaming is performed per-resource, this
+ *   parameter does not affect the return value. If page streaming is
+ *   performed per-page, this determines the maximum number of
+ *   resources in a page.
+ * @param {string=} request.filter
+ *   An expression for filtering the results of the request. Filter rules are
+ *   case insensitive. The fields eligible for filtering are:
+ *
+ *     * name
+ *     * display_name
+ *     * labels.key where key is the name of a label
+ *
+ *   Some examples of using filters are:
+ *
+ *     * name:* --> The instance has a name.
+ *     * name:Howl --> The instance's name contains the string "howl".
+ *     * name:HOWL --> Equivalent to above.
+ *     * NAME:howl --> Equivalent to above.
+ *     * labels.env:* --> The instance has the label "env".
+ *     * labels.env:dev --> The instance has the label "env" and the value of
+ *                          the label contains the string "dev".
+ *     * name:howl labels.env:dev --> The instance's name contains "howl" and
+ *                                    it has the label "env" with its value
+ *                                    containing "dev".
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @return {Stream}
+ *   An object stream which emits an object representing [Instance]{@link Instance} on 'data' event.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedParent = client.projectPath("[PROJECT]");
+ * client.listInstancesStream({parent: formattedParent}).on('data', function(element) {
+ *     // doThingsWith(element)
+ * }).on('error', function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.listInstancesStream = function(request, options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  return PAGE_DESCRIPTORS.listInstances.createStream(this._listInstances, request, options);
+};
+
+/**
+ * Gets information about a particular instance.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the requested instance. Values are of the form
+ *   `projects/<project>/instances/<instance>`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Instance]{@link Instance}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Instance]{@link Instance}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * client.getInstance({name: formattedName}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.getInstance = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getInstance(request, options, callback);
+};
+
+/**
+ * Creates an instance and begins preparing it to begin serving. The
+ * returned {@link long-running operation}
+ * can be used to track the progress of preparing the new
+ * instance. The instance name is assigned by the caller. If the
+ * named instance already exists, `CreateInstance` returns
+ * `ALREADY_EXISTS`.
+ *
+ * Immediately upon completion of this request:
+ *
+ *   * The instance is readable via the API, with all requested attributes
+ *     but no allocated resources. Its state is `CREATING`.
+ *
+ * Until completion of the returned operation:
+ *
+ *   * Cancelling the operation renders the instance immediately unreadable
+ *     via the API.
+ *   * The instance can be deleted.
+ *   * All other attempts to modify the instance are rejected.
+ *
+ * Upon completion of the returned operation:
+ *
+ *   * Billing for all successfully-allocated resources begins (some types
+ *     may have lower than the requested levels).
+ *   * Databases can be created in the instance.
+ *   * The instance's allocated resource levels are readable via the API.
+ *   * The instance's state becomes `READY`.
+ *
+ * The returned {@link long-running operation} will
+ * have a name of the format `<instance_name>/operations/<operation_id>` and
+ * can be used to track creation of the instance.  The
+ * {@link metadata} field type is
+ * {@link CreateInstanceMetadata}.
+ * The {@link response} field type is
+ * {@link Instance}, if successful.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The name of the project in which to create the instance. Values
+ *   are of the form `projects/<project>`.
+ * @param {string} request.instanceId
+ *   Required. The ID of the instance to create.  Valid identifiers are of the
+ *   form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 6 and 30 characters in
+ *   length.
+ * @param {Object} request.instance
+ *   Required. The instance to create.  The name may be omitted, but if
+ *   specified must be `<parent>/instances/<instance_id>`.
+ *
+ *   This object should have the same structure as [Instance]{@link Instance}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedParent = client.projectPath("[PROJECT]");
+ * var instanceId = '';
+ * var instance = {};
+ * var request = {
+ *     parent: formattedParent,
+ *     instanceId: instanceId,
+ *     instance: instance
+ * };
+ *
+ * // Handle the operation using the promise pattern.
+ * client.createInstance(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.createInstance(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.createInstance = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._createInstance(request, options, callback);
+};
+
+/**
+ * Updates an instance, and begins allocating or releasing resources
+ * as requested. The returned {@link long-running
+ * operation} can be used to track the
+ * progress of updating the instance. If the named instance does not
+ * exist, returns `NOT_FOUND`.
+ *
+ * Immediately upon completion of this request:
+ *
+ *   * For resource types for which a decrease in the instance's allocation
+ *     has been requested, billing is based on the newly-requested level.
+ *
+ * Until completion of the returned operation:
+ *
+ *   * Cancelling the operation sets its metadata's
+ *     {@link cancel_time}, and begins
+ *     restoring resources to their pre-request values. The operation
+ *     is guaranteed to succeed at undoing all resource changes,
+ *     after which point it terminates with a `CANCELLED` status.
+ *   * All other attempts to modify the instance are rejected.
+ *   * Reading the instance via the API continues to give the pre-request
+ *     resource levels.
+ *
+ * Upon completion of the returned operation:
+ *
+ *   * Billing begins for all successfully-allocated resources (some types
+ *     may have lower than the requested levels).
+ *   * All newly-reserved resources are available for serving the instance's
+ *     tables.
+ *   * The instance's new resource levels are readable via the API.
+ *
+ * The returned {@link long-running operation} will
+ * have a name of the format `<instance_name>/operations/<operation_id>` and
+ * can be used to track the instance modification.  The
+ * {@link metadata} field type is
+ * {@link UpdateInstanceMetadata}.
+ * The {@link response} field type is
+ * {@link Instance}, if successful.
+ *
+ * Authorization requires `spanner.instances.update` permission on
+ * resource {@link name}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {Object} request.instance
+ *   Required. The instance to update, which must always include the instance
+ *   name.  Otherwise, only fields mentioned in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask] need be included.
+ *
+ *   This object should have the same structure as [Instance]{@link Instance}
+ * @param {Object} request.fieldMask
+ *   Required. A mask specifying which fields in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.instance] should be updated.
+ *   The field mask must always be specified; this prevents any future fields in
+ *   [][google.spanner.admin.instance.v1.Instance] from being erased accidentally by clients that do not know
+ *   about them.
+ *
+ *   This object should have the same structure as [google.protobuf.FieldMask]{@link external:"google.protobuf.FieldMask"}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var instance = {};
+ * var fieldMask = {};
+ * var request = {
+ *     instance: instance,
+ *     fieldMask: fieldMask
+ * };
+ *
+ * // Handle the operation using the promise pattern.
+ * client.updateInstance(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.updateInstance(request).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.updateInstance = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._updateInstance(request, options, callback);
+};
+
+/**
+ * Deletes an instance.
+ *
+ * Immediately upon completion of the request:
+ *
+ *   * Billing ceases for all of the instance's reserved resources.
+ *
+ * Soon afterward:
+ *
+ *   * The instance and *all of its databases* immediately and
+ *     irrevocably disappear from the API. All data in the databases
+ *     is permanently deleted.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the instance to be deleted. Values are of the form
+ *   `projects/<project>/instances/<instance>`
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error)=} callback
+ *   The function which will be called with the result of the API call.
+ * @return {Promise} - The promise which resolves when API call finishes.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * client.deleteInstance({name: formattedName}).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.deleteInstance = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._deleteInstance(request, options, callback);
+};
+
+/**
+ * Sets the access control policy on an instance resource. Replaces any
+ * existing policy.
+ *
+ * Authorization requires `spanner.instances.setIamPolicy` on
+ * {@link resource}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy is being specified.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {Object} request.policy
+ *   REQUIRED: The complete policy to be applied to the `resource`. The size of
+ *   the policy is limited to a few 10s of KB. An empty policy is a
+ *   valid policy but certain Cloud Platform services (such as Projects)
+ *   might reject them.
+ *
+ *   This object should have the same structure as [Policy]{@link Policy}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Policy]{@link Policy}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Policy]{@link Policy}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * var policy = {};
+ * var request = {
+ *     resource: formattedResource,
+ *     policy: policy
+ * };
+ * client.setIamPolicy(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.setIamPolicy = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._setIamPolicy(request, options, callback);
+};
+
+/**
+ * Gets the access control policy for an instance resource. Returns an empty
+ * policy if an instance exists but does not have a policy set.
+ *
+ * Authorization requires `spanner.instances.getIamPolicy` on
+ * {@link resource}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy is being requested.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Policy]{@link Policy}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Policy]{@link Policy}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * client.getIamPolicy({resource: formattedResource}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.getIamPolicy = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getIamPolicy(request, options, callback);
+};
+
+/**
+ * Returns permissions that the caller has on the specified instance resource.
+ *
+ * Attempting this RPC on a non-existent Cloud Spanner instance resource will
+ * result in a NOT_FOUND error if the user has `spanner.instances.list`
+ * permission on the containing Google Cloud Project. Otherwise returns an
+ * empty set of permissions.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.resource
+ *   REQUIRED: The resource for which the policy detail is being requested.
+ *   `resource` is usually specified as a path. For example, a Project
+ *   resource is specified as `projects/{project}`.
+ * @param {string[]} request.permissions
+ *   The set of permissions to check for the `resource`. Permissions with
+ *   wildcards (such as '*' or 'storage.*') are not allowed. For more
+ *   information see
+ *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [TestIamPermissionsResponse]{@link TestIamPermissionsResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [TestIamPermissionsResponse]{@link TestIamPermissionsResponse}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.instanceAdminClient();
+ * var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+ * var permissions = [];
+ * var request = {
+ *     resource: formattedResource,
+ *     permissions: permissions
+ * };
+ * client.testIamPermissions(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+InstanceAdminClient.prototype.testIamPermissions = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._testIamPermissions(request, options, callback);
+};
+
+function InstanceAdminClientBuilder(gaxGrpc) {
+  if (!(this instanceof InstanceAdminClientBuilder)) {
+    return new InstanceAdminClientBuilder(gaxGrpc);
+  }
+
+  var instanceAdminClient = gaxGrpc.load([{
+    root: require('google-proto-files')('..'),
+    file: 'google/spanner/admin/instance/v1/spanner_instance_admin.proto'
+  }]);
+  extend(this, instanceAdminClient.google.spanner.admin.instance.v1);
+
+
+  /**
+   * Build a new instance of {@link InstanceAdminClient}.
+   *
+   * @param {Object=} opts - The optional parameters.
+   * @param {String=} opts.servicePath
+   *   The domain name of the API remote host.
+   * @param {number=} opts.port
+   *   The port on which to connect to the remote host.
+   * @param {grpc.ClientCredentials=} opts.sslCreds
+   *   A ClientCredentials for use with an SSL-enabled channel.
+   * @param {Object=} opts.clientConfig
+   *   The customized config to build the call settings. See
+   *   {@link gax.constructSettings} for the format.
+   */
+  this.instanceAdminClient = function(opts) {
+    return new InstanceAdminClient(gaxGrpc, instanceAdminClient, opts);
+  };
+  extend(this.instanceAdminClient, InstanceAdminClient);
+}
+module.exports = InstanceAdminClientBuilder;
+module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/instance_admin_client_config.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/src/v1/instance_admin_client_config.json
@@ -1,0 +1,78 @@
+{
+  "interfaces": {
+    "google.spanner.admin.instance.v1.InstanceAdmin": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 1000,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 32000,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "ListInstanceConfigs": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetInstanceConfig": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ListInstances": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetInstance": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateInstance": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateInstance": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteInstance": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "SetIamPolicy": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetIamPolicy": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "TestIamPermissions": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/test/test.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner-admin-instance/test/test.js
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var spannerV1 = require('../src/').v1();
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('InstanceAdminClient', function() {
+  describe('listInstanceConfigs', function() {
+    it('invokes listInstanceConfigs without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var instanceConfigsElement = {};
+      var instanceConfigs = [instanceConfigsElement];
+      var expectedResponse = {
+          nextPageToken : nextPageToken,
+          instanceConfigs : instanceConfigs
+      };
+
+      // Mock Grpc layer
+      client._listInstanceConfigs = function(actualRequest, options, callback) {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.instanceConfigs);
+      };
+
+      client.listInstanceConfigs(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.instanceConfigs);
+        done();
+      });
+    });
+
+    it('invokes listInstanceConfigs with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock Grpc layer
+      client._listInstanceConfigs = mockSimpleGrpcMethod(request, null, error);
+
+      client.listInstanceConfigs(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getInstanceConfig', function() {
+    it('invokes getInstanceConfig without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instanceConfigPath("[PROJECT]", "[INSTANCE_CONFIG]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var displayName = 'displayName1615086568';
+      var expectedResponse = {
+          name : name2,
+          displayName : displayName
+      };
+
+      // Mock Grpc layer
+      client._getInstanceConfig = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getInstanceConfig(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getInstanceConfig with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instanceConfigPath("[PROJECT]", "[INSTANCE_CONFIG]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._getInstanceConfig = mockSimpleGrpcMethod(request, null, error);
+
+      client.getInstanceConfig(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('listInstances', function() {
+    it('invokes listInstances without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var instancesElement = {};
+      var instances = [instancesElement];
+      var expectedResponse = {
+          nextPageToken : nextPageToken,
+          instances : instances
+      };
+
+      // Mock Grpc layer
+      client._listInstances = function(actualRequest, options, callback) {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.instances);
+      };
+
+      client.listInstances(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.instances);
+        done();
+      });
+    });
+
+    it('invokes listInstances with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var request = {
+          parent : formattedParent
+      };
+
+      // Mock Grpc layer
+      client._listInstances = mockSimpleGrpcMethod(request, null, error);
+
+      client.listInstances(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getInstance', function() {
+    it('invokes getInstance without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+          name : name2,
+          config : config,
+          displayName : displayName,
+          nodeCount : nodeCount
+      };
+
+      // Mock Grpc layer
+      client._getInstance = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getInstance(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getInstance with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._getInstance = mockSimpleGrpcMethod(request, null, error);
+
+      client.getInstance(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('createInstance', function() {
+    it('invokes createInstance without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var instanceId = 'instanceId-2101995259';
+      var instance = {};
+      var request = {
+          parent : formattedParent,
+          instanceId : instanceId,
+          instance : instance
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+          name : name,
+          config : config,
+          displayName : displayName,
+          nodeCount : nodeCount
+      };
+
+      // Mock Grpc layer
+      client._createInstance = mockLongRunningGrpcMethod(request, expectedResponse);
+
+      client.createInstance(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.deepStrictEqual(responses[0], expectedResponse);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes createInstance with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedParent = client.projectPath("[PROJECT]");
+      var instanceId = 'instanceId-2101995259';
+      var instance = {};
+      var request = {
+          parent : formattedParent,
+          instanceId : instanceId,
+          instance : instance
+      };
+
+      // Mock Grpc layer
+      client._createInstance = mockLongRunningGrpcMethod(request, null, error);
+
+      client.createInstance(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.fail();
+      }).catch(function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('updateInstance', function() {
+    it('invokes updateInstance without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var instance = {};
+      var fieldMask = {};
+      var request = {
+          instance : instance,
+          fieldMask : fieldMask
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+          name : name,
+          config : config,
+          displayName : displayName,
+          nodeCount : nodeCount
+      };
+
+      // Mock Grpc layer
+      client._updateInstance = mockLongRunningGrpcMethod(request, expectedResponse);
+
+      client.updateInstance(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.deepStrictEqual(responses[0], expectedResponse);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes updateInstance with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var instance = {};
+      var fieldMask = {};
+      var request = {
+          instance : instance,
+          fieldMask : fieldMask
+      };
+
+      // Mock Grpc layer
+      client._updateInstance = mockLongRunningGrpcMethod(request, null, error);
+
+      client.updateInstance(request).then(function(responses) {
+        var operation = responses[0];
+        return operation.promise();
+      }).then(function(responses) {
+        assert.fail();
+      }).catch(function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('deleteInstance', function() {
+    it('invokes deleteInstance without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._deleteInstance = mockSimpleGrpcMethod(request);
+
+      client.deleteInstance(request, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes deleteInstance with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedName = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._deleteInstance = mockSimpleGrpcMethod(request, null, error);
+
+      client.deleteInstance(request, function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('setIamPolicy', function() {
+    it('invokes setIamPolicy without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var policy = {};
+      var request = {
+          resource : formattedResource,
+          policy : policy
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+          version : version,
+          etag : etag
+      };
+
+      // Mock Grpc layer
+      client._setIamPolicy = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.setIamPolicy(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes setIamPolicy with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var policy = {};
+      var request = {
+          resource : formattedResource,
+          policy : policy
+      };
+
+      // Mock Grpc layer
+      client._setIamPolicy = mockSimpleGrpcMethod(request, null, error);
+
+      client.setIamPolicy(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getIamPolicy', function() {
+    it('invokes getIamPolicy without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          resource : formattedResource
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+          version : version,
+          etag : etag
+      };
+
+      // Mock Grpc layer
+      client._getIamPolicy = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getIamPolicy(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getIamPolicy with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var request = {
+          resource : formattedResource
+      };
+
+      // Mock Grpc layer
+      client._getIamPolicy = mockSimpleGrpcMethod(request, null, error);
+
+      client.getIamPolicy(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('testIamPermissions', function() {
+    it('invokes testIamPermissions without error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var permissions = [];
+      var request = {
+          resource : formattedResource,
+          permissions : permissions
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._testIamPermissions = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.testIamPermissions(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes testIamPermissions with error', function(done) {
+      var client = spannerV1.instanceAdminClient();
+      // Mock request
+      var formattedResource = client.instancePath("[PROJECT]", "[INSTANCE]");
+      var permissions = [];
+      var request = {
+          resource : formattedResource,
+          permissions : permissions
+      };
+
+      // Mock Grpc layer
+      client._testIamPermissions = mockSimpleGrpcMethod(request, null, error);
+
+      client.testIamPermissions(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockLongRunningGrpcMethod(expectedRequest, response, error) {
+  return function(request) {
+    assert.deepStrictEqual(request, expectedRequest);
+    var mockOperation = {
+      promise: function() {
+        return new Promise(function(resolve, reject) {
+          if (error) {
+            reject(error)
+          } else {
+            resolve([response]);
+          }
+        });
+      }
+    };
+    return Promise.resolve([mockOperation]);
+  };
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner/package.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner/package.json
@@ -1,0 +1,27 @@
+{
+  "url": "https://github.com/googleapis/googleapis",
+  "name": "@google-cloud/spanner",
+  "version": "0.7.1",
+  "author": "Google Inc",
+  "description": "Cloud Spanner API client for Node.js",
+  "main": "src/index.js",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "google-proto-files": "^0.10.0",
+    "google-gax": "^0.12.3",
+    "extend": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.12.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner/src/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner/src/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports.v1 = require('./v1');

--- a/generated/nodejs/google-cloud-node/packages/spanner/src/v1/index.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner/src/v1/index.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var spannerClient = require('./spanner_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  return spannerClient(gaxGrpc);
+}
+
+v1.SERVICE_ADDRESS = spannerClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = spannerClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/generated/nodejs/google-cloud-node/packages/spanner/src/v1/spanner_client.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner/src/v1/spanner_client.js
@@ -1,0 +1,956 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * EDITING INSTRUCTIONS
+ * This file was generated from the file
+ * https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto,
+ * and updates to that file get reflected here through a refresh process.
+ * For the short term, the refresh process will only be runnable by Google
+ * engineers.
+ *
+ * The only allowed edits are to method and file documentation. A 3-way
+ * merge preserves those additions if the generated source changes.
+ */
+/* TODO: introduce line-wrapping so that it never exceeds the limit. */
+/* jscs: disable maximumLineLength */
+'use strict';
+
+var configData = require('./spanner_client_config');
+var extend = require('extend');
+var gax = require('google-gax');
+
+var SERVICE_ADDRESS = 'spanner.googleapis.com';
+
+var DEFAULT_SERVICE_PORT = 443;
+
+var CODE_GEN_NAME_VERSION = 'gapic/0.7.1';
+
+var STREAM_DESCRIPTORS = {
+  executeStreamingSql: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+  streamingRead: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING)
+};
+
+/**
+ * The scopes needed to make gRPC calls to all of the methods defined in
+ * this service.
+ */
+var ALL_SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/spanner.data'
+];
+
+/**
+ * Cloud Spanner API
+ *
+ * The Cloud Spanner API can be used to manage sessions and execute
+ * transactions on data stored in Cloud Spanner databases.
+ *
+ * This will be created through a builder function which can be obtained by the module.
+ * See the following example of how to initialize the module and how to access to the builder.
+ * @see {@link spannerClient}
+ *
+ * @example
+ * var spannerV1 = require('@google-cloud/spanner').v1({
+ *   // optional auth parameters.
+ * });
+ * var client = spannerV1.spannerClient();
+ *
+ * @class
+ */
+function SpannerClient(gaxGrpc, grpcClients, opts) {
+  opts = extend({
+    servicePath: SERVICE_ADDRESS,
+    port: DEFAULT_SERVICE_PORT,
+    clientConfig: {}
+  }, opts);
+
+  var googleApiClient = [
+    'gl-node/' + process.versions.node
+  ];
+  if (opts.libName && opts.libVersion) {
+    googleApiClient.push(opts.libName + '/' + opts.libVersion);
+  }
+  googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
+    'grpc/' + gaxGrpc.grpcVersion
+  );
+
+  var defaults = gaxGrpc.constructSettings(
+      'google.spanner.v1.Spanner',
+      configData,
+      opts.clientConfig,
+      {'x-goog-api-client': googleApiClient.join(' ')});
+
+  var self = this;
+
+  this.auth = gaxGrpc.auth;
+  var spannerStub = gaxGrpc.createStub(
+      grpcClients.google.spanner.v1.Spanner,
+      opts);
+  var spannerStubMethods = [
+    'createSession',
+    'getSession',
+    'deleteSession',
+    'executeSql',
+    'executeStreamingSql',
+    'read',
+    'streamingRead',
+    'beginTransaction',
+    'commit',
+    'rollback'
+  ];
+  spannerStubMethods.forEach(function(methodName) {
+    self['_' + methodName] = gax.createApiCall(
+      spannerStub.then(function(spannerStub) {
+        return function() {
+          var args = Array.prototype.slice.call(arguments, 0);
+          return spannerStub[methodName].apply(spannerStub, args);
+        };
+      }),
+      defaults[methodName],
+      STREAM_DESCRIPTORS[methodName]);
+  });
+}
+
+// Path templates
+
+var DATABASE_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instances/{instance}/databases/{database}');
+
+var SESSION_PATH_TEMPLATE = new gax.PathTemplate(
+    'projects/{project}/instances/{instance}/databases/{database}/sessions/{session}');
+
+/**
+ * Returns a fully-qualified database resource name string.
+ * @param {String} project
+ * @param {String} instance
+ * @param {String} database
+ * @returns {String}
+ */
+SpannerClient.prototype.databasePath = function(project, instance, database) {
+  return DATABASE_PATH_TEMPLATE.render({
+    project: project,
+    instance: instance,
+    database: database
+  });
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the project.
+ */
+SpannerClient.prototype.matchProjectFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).project;
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the instance.
+ */
+SpannerClient.prototype.matchInstanceFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).instance;
+};
+
+/**
+ * Parses the databaseName from a database resource.
+ * @param {String} databaseName
+ *   A fully-qualified path representing a database resources.
+ * @returns {String} - A string representing the database.
+ */
+SpannerClient.prototype.matchDatabaseFromDatabaseName = function(databaseName) {
+  return DATABASE_PATH_TEMPLATE.match(databaseName).database;
+};
+
+/**
+ * Returns a fully-qualified session resource name string.
+ * @param {String} project
+ * @param {String} instance
+ * @param {String} database
+ * @param {String} session
+ * @returns {String}
+ */
+SpannerClient.prototype.sessionPath = function(project, instance, database, session) {
+  return SESSION_PATH_TEMPLATE.render({
+    project: project,
+    instance: instance,
+    database: database,
+    session: session
+  });
+};
+
+/**
+ * Parses the sessionName from a session resource.
+ * @param {String} sessionName
+ *   A fully-qualified path representing a session resources.
+ * @returns {String} - A string representing the project.
+ */
+SpannerClient.prototype.matchProjectFromSessionName = function(sessionName) {
+  return SESSION_PATH_TEMPLATE.match(sessionName).project;
+};
+
+/**
+ * Parses the sessionName from a session resource.
+ * @param {String} sessionName
+ *   A fully-qualified path representing a session resources.
+ * @returns {String} - A string representing the instance.
+ */
+SpannerClient.prototype.matchInstanceFromSessionName = function(sessionName) {
+  return SESSION_PATH_TEMPLATE.match(sessionName).instance;
+};
+
+/**
+ * Parses the sessionName from a session resource.
+ * @param {String} sessionName
+ *   A fully-qualified path representing a session resources.
+ * @returns {String} - A string representing the database.
+ */
+SpannerClient.prototype.matchDatabaseFromSessionName = function(sessionName) {
+  return SESSION_PATH_TEMPLATE.match(sessionName).database;
+};
+
+/**
+ * Parses the sessionName from a session resource.
+ * @param {String} sessionName
+ *   A fully-qualified path representing a session resources.
+ * @returns {String} - A string representing the session.
+ */
+SpannerClient.prototype.matchSessionFromSessionName = function(sessionName) {
+  return SESSION_PATH_TEMPLATE.match(sessionName).session;
+};
+
+/**
+ * Get the project ID used by this class.
+ * @aram {function(Error, string)} callback - the callback to be called with
+ *   the current project Id.
+ */
+SpannerClient.prototype.getProjectId = function(callback) {
+  return this.auth.getProjectId(callback);
+};
+
+// Service calls
+
+/**
+ * Creates a new session. A session can be used to perform
+ * transactions that read and/or modify data in a Cloud Spanner database.
+ * Sessions are meant to be reused for many consecutive
+ * transactions.
+ *
+ * Sessions can only execute one transaction at a time. To execute
+ * multiple concurrent read-write/write-only transactions, create
+ * multiple sessions. Note that standalone reads and queries use a
+ * transaction internally, and count toward the one transaction
+ * limit.
+ *
+ * Cloud Spanner limits the number of sessions that can exist at any given
+ * time; thus, it is a good idea to delete idle and/or unneeded sessions.
+ * Aside from explicit deletes, Cloud Spanner can delete sessions for which no
+ * operations are sent for more than an hour. If a session is deleted,
+ * requests to it return `NOT_FOUND`.
+ *
+ * Idle sessions can be kept alive by sending a trivial SQL query
+ * periodically, e.g., `"SELECT 1"`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.database
+ *   Required. The database in which the new session is created.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Session]{@link Session}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link Session}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+ * client.createSession({database: formattedDatabase}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.createSession = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._createSession(request, options, callback);
+};
+
+/**
+ * Gets a session. Returns `NOT_FOUND` if the session does not exist.
+ * This is mainly useful for determining whether a session is still
+ * alive.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the session to retrieve.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Session]{@link Session}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link Session}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * client.getSession({name: formattedName}).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.getSession = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getSession(request, options, callback);
+};
+
+/**
+ * Ends a session, releasing server resources associated with it.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the session to delete.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error)=} callback
+ *   The function which will be called with the result of the API call.
+ * @return {Promise} - The promise which resolves when API call finishes.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * client.deleteSession({name: formattedName}).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.deleteSession = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._deleteSession(request, options, callback);
+};
+
+/**
+ * Executes an SQL query, returning all rows in a single reply. This
+ * method cannot be used to return a result set larger than 10 MiB;
+ * if the query yields more data than that, the query fails with
+ * a `FAILED_PRECONDITION` error.
+ *
+ * Queries inside read-write transactions might return `ABORTED`. If
+ * this occurs, the application should restart the transaction from
+ * the beginning. See {@link Transaction} for more details.
+ *
+ * Larger result sets can be fetched in streaming fashion by calling
+ * {@link ExecuteStreamingSql} instead.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the SQL query should be performed.
+ * @param {string} request.sql
+ *   Required. The SQL query string.
+ * @param {Object=} request.transaction
+ *   The transaction to use. If none is provided, the default is a
+ *   temporary read-only transaction with strong concurrency.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link TransactionSelector}
+ * @param {Object=} request.params
+ *   The SQL query string can contain parameter placeholders. A parameter
+ *   placeholder consists of `'@'` followed by the parameter
+ *   name. Parameter names consist of any combination of letters,
+ *   numbers, and underscores.
+ *
+ *   Parameters can appear anywhere that a literal value is expected.  The same
+ *   parameter name can be used more than once, for example:
+ *     `"WHERE id > @msg_id AND id < @msg_id + 100"`
+ *
+ *   It is an error to execute an SQL query with unbound parameters.
+ *
+ *   Parameter values are specified using `params`, which is a JSON
+ *   object whose keys are parameter names, and whose values are the
+ *   corresponding parameter values.
+ *
+ *   This object should have the same structure as [google.protobuf.Struct]{@link external:"google.protobuf.Struct"}
+ * @param {Object.<string, Object>=} request.paramTypes
+ *   It is not always possible for Cloud Spanner to infer the right SQL type
+ *   from a JSON value.  For example, values of type `BYTES` and values
+ *   of type `STRING` both appear in {@link params} as JSON strings.
+ *
+ *   In these cases, `param_types` can be used to specify the exact
+ *   SQL type for some or all of the SQL query parameters. See the
+ *   definition of {@link Type} for more information
+ *   about SQL types.
+ * @param {string=} request.resumeToken
+ *   If this request is resuming a previously interrupted SQL query
+ *   execution, `resume_token` should be copied from the last
+ *   {@link PartialResultSet} yielded before the interruption. Doing this
+ *   enables the new SQL query execution to resume where the last one left
+ *   off. The rest of the request parameters must exactly match the
+ *   request that yielded this token.
+ * @param {number=} request.queryMode
+ *   Used to control the amount of debugging information returned in
+ *   {@link ResultSetStats}.
+ *
+ *   The number should be among the values of [QueryMode]{@link QueryMode}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [ResultSet]{@link ResultSet}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ResultSet]{@link ResultSet}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var sql = '';
+ * var request = {
+ *     session: formattedSession,
+ *     sql: sql
+ * };
+ * client.executeSql(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.executeSql = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._executeSql(request, options, callback);
+};
+
+/**
+ * Like {@link ExecuteSql}, except returns the result
+ * set as a stream. Unlike {@link ExecuteSql}, there
+ * is no limit on the size of the returned result set. However, no
+ * individual row in the result set can exceed 100 MiB, and no
+ * column value can exceed 10 MiB.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the SQL query should be performed.
+ * @param {string} request.sql
+ *   Required. The SQL query string.
+ * @param {Object=} request.transaction
+ *   The transaction to use. If none is provided, the default is a
+ *   temporary read-only transaction with strong concurrency.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link TransactionSelector}
+ * @param {Object=} request.params
+ *   The SQL query string can contain parameter placeholders. A parameter
+ *   placeholder consists of `'@'` followed by the parameter
+ *   name. Parameter names consist of any combination of letters,
+ *   numbers, and underscores.
+ *
+ *   Parameters can appear anywhere that a literal value is expected.  The same
+ *   parameter name can be used more than once, for example:
+ *     `"WHERE id > @msg_id AND id < @msg_id + 100"`
+ *
+ *   It is an error to execute an SQL query with unbound parameters.
+ *
+ *   Parameter values are specified using `params`, which is a JSON
+ *   object whose keys are parameter names, and whose values are the
+ *   corresponding parameter values.
+ *
+ *   This object should have the same structure as [google.protobuf.Struct]{@link external:"google.protobuf.Struct"}
+ * @param {Object.<string, Object>=} request.paramTypes
+ *   It is not always possible for Cloud Spanner to infer the right SQL type
+ *   from a JSON value.  For example, values of type `BYTES` and values
+ *   of type `STRING` both appear in {@link params} as JSON strings.
+ *
+ *   In these cases, `param_types` can be used to specify the exact
+ *   SQL type for some or all of the SQL query parameters. See the
+ *   definition of {@link Type} for more information
+ *   about SQL types.
+ * @param {string=} request.resumeToken
+ *   If this request is resuming a previously interrupted SQL query
+ *   execution, `resume_token` should be copied from the last
+ *   {@link PartialResultSet} yielded before the interruption. Doing this
+ *   enables the new SQL query execution to resume where the last one left
+ *   off. The rest of the request parameters must exactly match the
+ *   request that yielded this token.
+ * @param {number=} request.queryMode
+ *   Used to control the amount of debugging information returned in
+ *   {@link ResultSetStats}.
+ *
+ *   The number should be among the values of [QueryMode]{@link QueryMode}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @returns {Stream}
+ *   An object stream which emits [PartialResultSet]{@link PartialResultSet} on 'data' event.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var sql = '';
+ * var request = {
+ *     session: formattedSession,
+ *     sql: sql
+ * };
+ * client.executeStreamingSql(request).on('data', function(response) {
+ *     // doThingsWith(response)
+ * });
+ */
+SpannerClient.prototype.executeStreamingSql = function(request, options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._executeStreamingSql(request, options);
+};
+
+/**
+ * Reads rows from the database using key lookups and scans, as a
+ * simple key/value style alternative to
+ * {@link ExecuteSql}.  This method cannot be used to
+ * return a result set larger than 10 MiB; if the read matches more
+ * data than that, the read fails with a `FAILED_PRECONDITION`
+ * error.
+ *
+ * Reads inside read-write transactions might return `ABORTED`. If
+ * this occurs, the application should restart the transaction from
+ * the beginning. See {@link Transaction} for more details.
+ *
+ * Larger result sets can be yielded in streaming fashion by calling
+ * {@link StreamingRead} instead.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the read should be performed.
+ * @param {string} request.table
+ *   Required. The name of the table in the database to be read.
+ * @param {string[]} request.columns
+ *   The columns of {@link table} to be returned for each row matching
+ *   this request.
+ * @param {Object} request.keySet
+ *   Required. `key_set` identifies the rows to be yielded. `key_set` names the
+ *   primary keys of the rows in {@link table} to be yielded, unless {@link index}
+ *   is present. If {@link index} is present, then {@link key_set} instead names
+ *   index keys in {@link index}.
+ *
+ *   Rows are yielded in table primary key order (if {@link index} is empty)
+ *   or index key order (if {@link index} is non-empty).
+ *
+ *   It is not an error for the `key_set` to name rows that do not
+ *   exist in the database. Read yields nothing for nonexistent rows.
+ *
+ *   This object should have the same structure as [KeySet]{@link KeySet}
+ * @param {Object=} request.transaction
+ *   The transaction to use. If none is provided, the default is a
+ *   temporary read-only transaction with strong concurrency.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link TransactionSelector}
+ * @param {string=} request.index
+ *   If non-empty, the name of an index on {@link table}. This index is
+ *   used instead of the table primary key when interpreting {@link key_set}
+ *   and sorting result rows. See {@link key_set} for further information.
+ * @param {number=} request.limit
+ *   If greater than zero, only the first `limit` rows are yielded. If `limit`
+ *   is zero, the default is no limit.
+ * @param {string=} request.resumeToken
+ *   If this request is resuming a previously interrupted read,
+ *   `resume_token` should be copied from the last
+ *   {@link PartialResultSet} yielded before the interruption. Doing this
+ *   enables the new read to resume where the last read left off. The
+ *   rest of the request parameters must exactly match the request
+ *   that yielded this token.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [ResultSet]{@link ResultSet}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ResultSet]{@link ResultSet}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var table = '';
+ * var columns = [];
+ * var keySet = {};
+ * var request = {
+ *     session: formattedSession,
+ *     table: table,
+ *     columns: columns,
+ *     keySet: keySet
+ * };
+ * client.read(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.read = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._read(request, options, callback);
+};
+
+/**
+ * Like {@link Read}, except returns the result set as a
+ * stream. Unlike {@link Read}, there is no limit on the
+ * size of the returned result set. However, no individual row in
+ * the result set can exceed 100 MiB, and no column value can exceed
+ * 10 MiB.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the read should be performed.
+ * @param {string} request.table
+ *   Required. The name of the table in the database to be read.
+ * @param {string[]} request.columns
+ *   The columns of {@link table} to be returned for each row matching
+ *   this request.
+ * @param {Object} request.keySet
+ *   Required. `key_set` identifies the rows to be yielded. `key_set` names the
+ *   primary keys of the rows in {@link table} to be yielded, unless {@link index}
+ *   is present. If {@link index} is present, then {@link key_set} instead names
+ *   index keys in {@link index}.
+ *
+ *   Rows are yielded in table primary key order (if {@link index} is empty)
+ *   or index key order (if {@link index} is non-empty).
+ *
+ *   It is not an error for the `key_set` to name rows that do not
+ *   exist in the database. Read yields nothing for nonexistent rows.
+ *
+ *   This object should have the same structure as [KeySet]{@link KeySet}
+ * @param {Object=} request.transaction
+ *   The transaction to use. If none is provided, the default is a
+ *   temporary read-only transaction with strong concurrency.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link TransactionSelector}
+ * @param {string=} request.index
+ *   If non-empty, the name of an index on {@link table}. This index is
+ *   used instead of the table primary key when interpreting {@link key_set}
+ *   and sorting result rows. See {@link key_set} for further information.
+ * @param {number=} request.limit
+ *   If greater than zero, only the first `limit` rows are yielded. If `limit`
+ *   is zero, the default is no limit.
+ * @param {string=} request.resumeToken
+ *   If this request is resuming a previously interrupted read,
+ *   `resume_token` should be copied from the last
+ *   {@link PartialResultSet} yielded before the interruption. Doing this
+ *   enables the new read to resume where the last read left off. The
+ *   rest of the request parameters must exactly match the request
+ *   that yielded this token.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @returns {Stream}
+ *   An object stream which emits [PartialResultSet]{@link PartialResultSet} on 'data' event.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var table = '';
+ * var columns = [];
+ * var keySet = {};
+ * var request = {
+ *     session: formattedSession,
+ *     table: table,
+ *     columns: columns,
+ *     keySet: keySet
+ * };
+ * client.streamingRead(request).on('data', function(response) {
+ *     // doThingsWith(response)
+ * });
+ */
+SpannerClient.prototype.streamingRead = function(request, options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._streamingRead(request, options);
+};
+
+/**
+ * Begins a new transaction. This step can often be skipped:
+ * {@link Read}, {@link ExecuteSql} and
+ * {@link Commit} can begin a new transaction as a
+ * side-effect.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the transaction runs.
+ * @param {Object} request.options
+ *   Required. Options for the new transaction.
+ *
+ *   This object should have the same structure as [TransactionOptions]{@link TransactionOptions}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [Transaction]{@link Transaction}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Transaction]{@link Transaction}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var options = {};
+ * var request = {
+ *     session: formattedSession,
+ *     options: options
+ * };
+ * client.beginTransaction(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.beginTransaction = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._beginTransaction(request, options, callback);
+};
+
+/**
+ * Commits a transaction. The request includes the mutations to be
+ * applied to rows in the database.
+ *
+ * `Commit` might return an `ABORTED` error. This can occur at any time;
+ * commonly, the cause is conflicts with concurrent
+ * transactions. However, it can also happen for a variety of other
+ * reasons. If `Commit` returns `ABORTED`, the caller should re-attempt
+ * the transaction from the beginning, re-using the same session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the transaction to be committed is running.
+ * @param {Object[]} request.mutations
+ *   The mutations to be executed when this transaction commits. All
+ *   mutations are applied atomically, in the order they appear in
+ *   this list.
+ *
+ *   This object should have the same structure as [Mutation]{@link Mutation}
+ * @param {string=} request.transactionId
+ *   Commit a previously-started transaction.
+ * @param {Object=} request.singleUseTransaction
+ *   Execute mutations in a temporary transaction. Note that unlike
+ *   commit of a previously-started transaction, commit with a
+ *   temporary transaction is non-idempotent. That is, if the
+ *   `CommitRequest` is sent to Cloud Spanner more than once (for
+ *   instance, due to retries in the application, or in the
+ *   transport library), it is possible that the mutations are
+ *   executed more than once. If this is undesirable, use
+ *   {@link BeginTransaction} and
+ *   {@link Commit} instead.
+ *
+ *   This object should have the same structure as [TransactionOptions]{@link TransactionOptions}
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [CommitResponse]{@link CommitResponse}.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [CommitResponse]{@link CommitResponse}.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var mutations = [];
+ * var request = {
+ *     session: formattedSession,
+ *     mutations: mutations
+ * };
+ * client.commit(request).then(function(responses) {
+ *     var response = responses[0];
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.commit = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._commit(request, options, callback);
+};
+
+/**
+ * Rolls back a transaction, releasing any locks it holds. It is a good
+ * idea to call this for any transaction that includes one or more
+ * {@link Read} or {@link ExecuteSql} requests and
+ * ultimately decides not to commit.
+ *
+ * `Rollback` returns `OK` if it successfully aborts the transaction, the
+ * transaction was already aborted, or the transaction is not
+ * found. `Rollback` never returns `ABORTED`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.session
+ *   Required. The session in which the transaction to roll back is running.
+ * @param {string} request.transactionId
+ *   Required. The transaction to roll back.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error)=} callback
+ *   The function which will be called with the result of the API call.
+ * @return {Promise} - The promise which resolves when API call finishes.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = spannerV1.spannerClient();
+ * var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+ * var transactionId = '';
+ * var request = {
+ *     session: formattedSession,
+ *     transactionId: transactionId
+ * };
+ * client.rollback(request).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+SpannerClient.prototype.rollback = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._rollback(request, options, callback);
+};
+
+function SpannerClientBuilder(gaxGrpc) {
+  if (!(this instanceof SpannerClientBuilder)) {
+    return new SpannerClientBuilder(gaxGrpc);
+  }
+
+  var spannerClient = gaxGrpc.load([{
+    root: require('google-proto-files')('..'),
+    file: 'google/spanner/v1/spanner.proto'
+  }]);
+  extend(this, spannerClient.google.spanner.v1);
+
+
+  /**
+   * Build a new instance of {@link SpannerClient}.
+   *
+   * @param {Object=} opts - The optional parameters.
+   * @param {String=} opts.servicePath
+   *   The domain name of the API remote host.
+   * @param {number=} opts.port
+   *   The port on which to connect to the remote host.
+   * @param {grpc.ClientCredentials=} opts.sslCreds
+   *   A ClientCredentials for use with an SSL-enabled channel.
+   * @param {Object=} opts.clientConfig
+   *   The customized config to build the call settings. See
+   *   {@link gax.constructSettings} for the format.
+   */
+  this.spannerClient = function(opts) {
+    return new SpannerClient(gaxGrpc, spannerClient, opts);
+  };
+  extend(this.spannerClient, SpannerClient);
+}
+module.exports = SpannerClientBuilder;
+module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/generated/nodejs/google-cloud-node/packages/spanner/src/v1/spanner_client_config.json
+++ b/generated/nodejs/google-cloud-node/packages/spanner/src/v1/spanner_client_config.json
@@ -1,0 +1,78 @@
+{
+  "interfaces": {
+    "google.spanner.v1.Spanner": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 1000,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 32000,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "CreateSession": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetSession": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteSession": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ExecuteSql": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ExecuteStreamingSql": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "Read": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingRead": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "BeginTransaction": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "Commit": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "Rollback": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner/test/test.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner/test/test.js
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var spannerV1 = require('../src/').v1();
+var through2 = require('through2');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('SpannerClient', function() {
+  describe('createSession', function() {
+    it('invokes createSession without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var expectedResponse = {
+          name : name
+      };
+
+      // Mock Grpc layer
+      client._createSession = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.createSession(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes createSession with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedDatabase = client.databasePath("[PROJECT]", "[INSTANCE]", "[DATABASE]");
+      var request = {
+          database : formattedDatabase
+      };
+
+      // Mock Grpc layer
+      client._createSession = mockSimpleGrpcMethod(request, null, error);
+
+      client.createSession(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getSession', function() {
+    it('invokes getSession without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var expectedResponse = {
+          name : name2
+      };
+
+      // Mock Grpc layer
+      client._getSession = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.getSession(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getSession with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._getSession = mockSimpleGrpcMethod(request, null, error);
+
+      client.getSession(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('deleteSession', function() {
+    it('invokes deleteSession without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._deleteSession = mockSimpleGrpcMethod(request);
+
+      client.deleteSession(request, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes deleteSession with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedName = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._deleteSession = mockSimpleGrpcMethod(request, null, error);
+
+      client.deleteSession(request, function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('executeSql', function() {
+    it('invokes executeSql without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var sql = 'sql114126';
+      var request = {
+          session : formattedSession,
+          sql : sql
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._executeSql = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.executeSql(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes executeSql with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var sql = 'sql114126';
+      var request = {
+          session : formattedSession,
+          sql : sql
+      };
+
+      // Mock Grpc layer
+      client._executeSql = mockSimpleGrpcMethod(request, null, error);
+
+      client.executeSql(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('executeStreamingSql', function() {
+    it('invokes executeStreamingSql without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var sql = 'sql114126';
+      var request = {
+          session : formattedSession,
+          sql : sql
+      };
+
+      // Mock response
+      var chunkedValue = true;
+      var resumeToken = '103';
+      var expectedResponse = {
+          chunkedValue : chunkedValue,
+          resumeToken : resumeToken
+      };
+
+      // Mock Grpc layer
+      client._executeStreamingSql = mockServerStreamingGrpcMethod(request, expectedResponse);
+
+      client.executeStreamingSql(request).on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      }).on('error', function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes executeStreamingSql with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var sql = 'sql114126';
+      var request = {
+          session : formattedSession,
+          sql : sql
+      };
+
+      // Mock Grpc layer
+      client._executeStreamingSql = mockServerStreamingGrpcMethod(request, null, error);
+
+      client.executeStreamingSql(request).on('data', function(response) {
+        assert.fail();
+      }).on('error', function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('read', function() {
+    it('invokes read without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+          session : formattedSession,
+          table : table,
+          columns : columns,
+          keySet : keySet
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._read = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.read(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes read with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+          session : formattedSession,
+          table : table,
+          columns : columns,
+          keySet : keySet
+      };
+
+      // Mock Grpc layer
+      client._read = mockSimpleGrpcMethod(request, null, error);
+
+      client.read(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('streamingRead', function() {
+    it('invokes streamingRead without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+          session : formattedSession,
+          table : table,
+          columns : columns,
+          keySet : keySet
+      };
+
+      // Mock response
+      var chunkedValue = true;
+      var resumeToken = '103';
+      var expectedResponse = {
+          chunkedValue : chunkedValue,
+          resumeToken : resumeToken
+      };
+
+      // Mock Grpc layer
+      client._streamingRead = mockServerStreamingGrpcMethod(request, expectedResponse);
+
+      client.streamingRead(request).on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      }).on('error', function(err) {
+        done(err);
+      });
+    });
+
+    it('invokes streamingRead with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+          session : formattedSession,
+          table : table,
+          columns : columns,
+          keySet : keySet
+      };
+
+      // Mock Grpc layer
+      client._streamingRead = mockServerStreamingGrpcMethod(request, null, error);
+
+      client.streamingRead(request).on('data', function(response) {
+        assert.fail();
+      }).on('error', function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('beginTransaction', function() {
+    it('invokes beginTransaction without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var options = {};
+      var request = {
+          session : formattedSession,
+          options : options
+      };
+
+      // Mock response
+      var id = '27';
+      var expectedResponse = {
+          id : id
+      };
+
+      // Mock Grpc layer
+      client._beginTransaction = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.beginTransaction(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes beginTransaction with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var options = {};
+      var request = {
+          session : formattedSession,
+          options : options
+      };
+
+      // Mock Grpc layer
+      client._beginTransaction = mockSimpleGrpcMethod(request, null, error);
+
+      client.beginTransaction(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('commit', function() {
+    it('invokes commit without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var mutations = [];
+      var request = {
+          session : formattedSession,
+          mutations : mutations
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._commit = mockSimpleGrpcMethod(request, expectedResponse);
+
+      client.commit(request, function(err, response) {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes commit with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var mutations = [];
+      var request = {
+          session : formattedSession,
+          mutations : mutations
+      };
+
+      // Mock Grpc layer
+      client._commit = mockSimpleGrpcMethod(request, null, error);
+
+      client.commit(request, function(err, response) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('rollback', function() {
+    it('invokes rollback without error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var transactionId = '28';
+      var request = {
+          session : formattedSession,
+          transactionId : transactionId
+      };
+
+      // Mock Grpc layer
+      client._rollback = mockSimpleGrpcMethod(request);
+
+      client.rollback(request, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes rollback with error', function(done) {
+      var client = spannerV1.spannerClient();
+      // Mock request
+      var formattedSession = client.sessionPath("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
+      var transactionId = '28';
+      var request = {
+          session : formattedSession,
+          transactionId : transactionId
+      };
+
+      // Mock Grpc layer
+      client._rollback = mockSimpleGrpcMethod(request, null, error);
+
+      client.rollback(request, function(err) {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    var mockStream = through2.obj(function (chunk, enc, callback) {
+      if (error) {
+        callback(error);
+      } else {
+        callback(null, response);
+      }
+    });
+    mockStream.write();
+    return mockStream;
+  };
+}

--- a/generated/nodejs/google-cloud-node/packages/spanner/test/test.js
+++ b/generated/nodejs/google-cloud-node/packages/spanner/test/test.js
@@ -519,7 +519,7 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
         callback(null, response);
       }
     });
-    mockStream.write();
+    setTimeout(function() { mockStream.write(); }, 0);
     return mockStream;
   };
 }


### PR DESCRIPTION
This has several manual updates actually. We should fix those
manual efforts eventually;
- streaming methods with errors test cases fail. This is because
  of nodejs behavior where delivery of 'data' events are queued
  but unhandled 'error' events actually throw the error immediately.
  See: https://github.com/googleapis/toolkit/issues/1108
- the path name and module name confusion for spanner admin
  APIs.