### PR TITLE
Add no-op CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ubuntu:16.04
+    steps:
+      - run:
+          name: No-op.
+          command: echo "This command did nothing. It exists to configure CircleCI so that PRs that supply actual configuration will work."


### PR DESCRIPTION
This is a bogus baseline CI config so that I can properly set up the _actual_ configuration in a forthcoming pull request.