### PR TITLE
Add Java CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ jobs:
       - run:
           name: Run GAPIC unit tests.
           command: |
-            export TERM=dumb
             ./gradlew clean test
     working_directory: /var/code/googleapis/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,8 @@ jobs:
   openjdk7:
     docker:
       - image: openjdk:7
+        environment:
+          TERM: dumb
     steps:
       - checkout
       - run:
@@ -113,12 +115,13 @@ jobs:
   openjdk8:
     docker:
       - image: openjdk:8
+        environment:
+          TERM: dumb
     steps:
       - checkout
       - run:
           name: Run GAPIC unit tests.
           command: |
-            export TERM=dumb
             ./gradlew clean test
     working_directory: /var/code/googleapis/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
             ./trigger_job.sh python34
             ./trigger_job.sh python35
             ./trigger_job.sh python36
+      - run:
+          name: 'Trigger jobs: Java Unit Tests'
+          command: |
+            ./trigger_job.sh openjdk7
+            ./trigger_job.sh openjdk8
       - deploy:
           name: Sync to api-client-staging-private (if this is master).
           command: |
@@ -91,6 +96,28 @@ jobs:
           command: |
             nox --noxfile generated/python/nox.py \
                 --sessions "unit_tests(python_version='3.6')"
+    working_directory: /var/code/googleapis/
+
+  openjdk7:
+    docker:
+      - image: 7-jdk
+    steps:
+      - checkout
+      - run:
+          name: Run GAPIC unit tests.
+          command: |
+            ./gradlew clean test
+    working_directory: /var/code/googleapis/
+
+  openjdk8:
+    docker:
+      - image: 8-jdk
+    steps:
+      - checkout
+      - run:
+          name: Run GAPIC unit tests.
+          command: |
+            ./gradlew clean test
     working_directory: /var/code/googleapis/
 
   sync_to_private:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,23 +100,25 @@ jobs:
 
   openjdk7:
     docker:
-      - image: 7-jdk
+      - image: openjdk:7
     steps:
       - checkout
       - run:
           name: Run GAPIC unit tests.
           command: |
+            export TERM=dumb
             ./gradlew clean test
     working_directory: /var/code/googleapis/
 
   openjdk8:
     docker:
-      - image: 8-jdk
+      - image: openjdk:8
     steps:
       - checkout
       - run:
           name: Run GAPIC unit tests.
           command: |
+            export TERM=dumb
             ./gradlew clean test
     working_directory: /var/code/googleapis/
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-bin.zip


### PR DESCRIPTION
Java unit tests pass in openjdk7 & 8 (Please ignore the python tests failures)

Note: This PR updates gradle to 2.11 since 2.0 gave us "peer not authenticated" error when resolving dependency.