### PR TITLE
Fix Node 4 unit tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: 'Trigger jobs: Node.js Unit Tests'
           command: |
-            # ./trigger_job.sh node4
+            ./trigger_job.sh node4
             ./trigger_job.sh node6
             ./trigger_job.sh node7
       - run:
@@ -58,7 +58,10 @@ jobs:
           name: Run GAPIC unit tests in Node 4.
           command: |
             cd generated/nodejs/
-            npm test
+            
+            # Node 4 needs a special command because it is less forgiving
+            # about finding the right packages when installed from the top.
+            ./runtests.sh
     working_directory: /var/code/googleapis/
 
   node6:

--- a/generated/nodejs/iam/package.json
+++ b/generated/nodejs/iam/package.json
@@ -23,7 +23,8 @@
       "Google Identity and Access Management (IAM) API"
   ],
   "dependencies": {
-    "google-gax": "^0.12.2",
+    "google-gax": "^0.12.3",
+    "google-proto-files": "^0.12.0",
     "extend": "^3.0.0"
   },
   "devDependencies": {

--- a/generated/nodejs/runtests.sh
+++ b/generated/nodejs/runtests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+EXIT_CODE=0
+
+function run_npm_test {
+  cd $1
+
+  # Install dependencies.
+  npm install
+  INSTALL_RESULT=$?
+  if [ $INSTALL_RESULT -ne 0 ]; then
+    return $INSTALL_RESULT
+  fi
+
+  # Run the tests.
+  npm test
+  TEST_RESULT=$?
+  cd ..
+  return $TEST_RESULT
+}
+
+
+for DIR in ./*/; do
+  # Sanity check: Do not attempt to test bogus packages.
+  if [ ! -f $DIR/package.json ]; then
+    continue
+  fi
+
+  # Run the tests.
+  echo "Running tests: $DIR"
+  echo '-------------------'
+  run_npm_test $DIR
+  SUCCESS=$?
+  if [ $SUCCESS -ne 0 ]; then
+    EXIT_CODE=$SUCCESS
+  fi
+done
+exit $EXIT_CODE


### PR DESCRIPTION
This PR makes unit tests run (and pass) in Node 4, bringing our Node coverage to all supported versions (as of this writing: 4, 6, and 7).