### PR TITLE
Set openjdk7 to use a specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   openjdk7:
     docker:
-      - image: openjdk:7
+      - image: openjdk:7u111
         environment:
           TERM: dumb
     steps:
@@ -108,7 +108,7 @@ jobs:
       - run:
           name: Run GAPIC unit tests in OpenJDK 7.
           command: |
-            ./generated/java/gradlew -p ./generated/java clean test --debug
+            ./generated/java/gradlew -p ./generated/java clean test
     working_directory: /var/code/googleapis/
 
   openjdk8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - run:
           name: Run GAPIC unit tests in OpenJDK 7.
           command: |
-            ./generated/java/gradlew -p ./generated/java clean test
+            ./generated/java/gradlew -p ./generated/java clean test --debug
     working_directory: /var/code/googleapis/
 
   openjdk8:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM openjdk:7
-
-WORKDIR /api-client-staging
-
-ADD . /api-client-staging
-
-RUN ./generated/java/gradlew -p ./generated/java clean test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:7
+
+WORKDIR /api-client-staging
+
+ADD . /api-client-staging
+
+RUN ./generated/java/gradlew -p ./generated/java clean test


### PR DESCRIPTION
The latest openJDK7 (131) image introduces a SSL security issue. (Already reported [here](https://github.com/docker-library/openjdk/issues/117))

An older version solves the test failures. We can revert to use the latest image once the issue is resolved at their end.