### PR TITLE
Update build files to support batch javadoc update

### DIFF
--- a/generated/java/grpc-google-cloud-error-reporting-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-error-reporting-v1beta1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-error-reporting-v1beta1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-language-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-language-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-language-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-language-v1beta2/build.gradle
+++ b/generated/java/grpc-google-cloud-language-v1beta2/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-language-v1beta2'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-logging-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-logging-v2/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-logging-v2'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-monitoring-v3/build.gradle
+++ b/generated/java/grpc-google-cloud-monitoring-v3/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-monitoring-v3'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-pubsub-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-pubsub-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-pubsub-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-spanner-admin-database-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-admin-database-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-spanner-admin-database-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-spanner-admin-instance-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-admin-instance-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-spanner-admin-instance-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-spanner-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-spanner-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-speech-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-speech-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-speech-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-speech-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-speech-v1beta1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-speech-v1beta1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-trace-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-trace-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-trace-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-cloud-vision-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-vision-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-vision-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-common-protos/build.gradle
+++ b/generated/java/grpc-google-common-protos/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-common-protos'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-iam-v1/build.gradle
+++ b/generated/java/grpc-google-iam-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-iam-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/grpc-google-longrunning-v1/build.gradle
+++ b/generated/java/grpc-google-longrunning-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-longrunning-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-error-reporting-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-error-reporting-v1beta1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-error-reporting-v1beta1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-language-v1/build.gradle
+++ b/generated/java/proto-google-cloud-language-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-language-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-language-v1beta2/build.gradle
+++ b/generated/java/proto-google-cloud-language-v1beta2/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-language-v1beta2'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-logging-v2/build.gradle
+++ b/generated/java/proto-google-cloud-logging-v2/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-logging-v2'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-monitoring-v3/build.gradle
+++ b/generated/java/proto-google-cloud-monitoring-v3/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-monitoring-v3'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-pubsub-v1/build.gradle
+++ b/generated/java/proto-google-cloud-pubsub-v1/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-pubsub-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -110,8 +111,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -122,7 +124,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -131,20 +133,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -152,7 +155,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-spanner-admin-database-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-admin-database-v1/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-spanner-admin-database-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -110,8 +111,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -122,7 +124,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -131,20 +133,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -152,7 +155,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-spanner-admin-instance-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-admin-instance-v1/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-spanner-admin-instance-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -110,8 +111,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -122,7 +124,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -131,20 +133,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -152,7 +155,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-spanner-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-spanner-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-speech-v1/build.gradle
+++ b/generated/java/proto-google-cloud-speech-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-speech-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-speech-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-speech-v1beta1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-speech-v1beta1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-trace-v1/build.gradle
+++ b/generated/java/proto-google-cloud-trace-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-trace-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-cloud-vision-v1/build.gradle
+++ b/generated/java/proto-google-cloud-vision-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-vision-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-common-protos/build.gradle
+++ b/generated/java/proto-google-common-protos/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-common-protos'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -108,8 +109,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -120,7 +122,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -129,20 +131,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -150,7 +153,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-iam-v1/build.gradle
+++ b/generated/java/proto-google-iam-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-iam-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }

--- a/generated/java/proto-google-longrunning-v1/build.gradle
+++ b/generated/java/proto-google-longrunning-v1/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-longrunning-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -109,8 +110,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -121,7 +123,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -130,20 +132,21 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'
@@ -151,7 +154,14 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
-  dependsOn 'createApiDocsRedirect'
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'updateDocs'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }


### PR DESCRIPTION
- Switch to use absolute paths in the build.gradle
- Set `projectDir` for each submodule in the root settings

After this PR you can run to batch update the javadoc for all gRPC/Proto packages
```
./gradlew updateAndPushDocs
```

cc/ @lukesneeringer 