### PR TITLE
java: update gax dependency, making tests pass

### DIFF
--- a/generated/java/build.gradle
+++ b/generated/java/build.gradle
@@ -29,8 +29,8 @@ subprojects {
   ext {
     // Shortcuts for libraries we are using
     libraries = [
-        gax: 'com.google.api:gax:1.3.1',
-        gaxGrpc: 'com.google.api:gax-grpc:0.20.0',
+        gax: 'com.google.api:gax:1.4.1',
+        gaxGrpc: 'com.google.api:gax-grpc:0.21.1',
 
         // Testing
         junit: 'junit:junit:4.11',

--- a/generated/java/google-longrunning-v1/build.gradle
+++ b/generated/java/google-longrunning-v1/build.gradle
@@ -1,0 +1,31 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+apply plugin: 'java'
+
+description = 'GAPIC library for google-longrunning-v1'
+group = "com.google.api"
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+repositories {
+  mavenCentral()
+  mavenLocal()
+}
+
+dependencies {
+  compile project(":proto-google-longrunning-v1")
+  compile libraries.gax, libraries.gaxGrpc
+  testCompile project(":grpc-google-longrunning-v1")
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src/main/java'
+    }
+  }
+}


### PR DESCRIPTION
gax dependency is updated to 1.4.1, following googleapis/gax-java#332.

google-longrunning-v1 now has its own build.gradle,
since its dependencies were removed
and inadvertently not replaced
in #361.