### PR TITLE
Add CI for PHP 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,19 @@ jobs:
                 --sessions "unit_tests(python_version='3.6')"
     working_directory: /var/code/googleapis/
 
+  php5:
+    docker:
+      - image: googleapis/php:5
+    steps:
+      - checkout
+      - run:
+          name: Install PHP library
+          command: composer install
+      - run:
+          name: Run GAPIC unit tests in PHP 5
+          command: ./vendor/bin/phpunit
+    working_directory: /var/code/googleapis/
+
   sync_to_private:
     docker:
       - image: googleapis/git
@@ -191,6 +204,7 @@ workflows:
       - python34
       - python35
       - python36
+      - php5
       - sync:
           requires:
             - go17
@@ -204,6 +218,7 @@ workflows:
             - python34
             - python35
             - python36
+            - php5
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
                 --sessions "unit_tests(python_version='3.6')"
     working_directory: /var/code/googleapis/
 
-  php5:
+  php56:
     docker:
       - image: googleapis/php:5
     steps:
@@ -172,7 +172,7 @@ jobs:
           name: Install PHP library
           command: composer install
       - run:
-          name: Run GAPIC unit tests in PHP 5
+          name: Run GAPIC unit tests in PHP 5.6
           command: ./vendor/bin/phpunit
     working_directory: /var/code/googleapis/
 
@@ -204,7 +204,7 @@ workflows:
       - python34
       - python35
       - python36
-      - php5
+      - php56
       - sync:
           requires:
             - go17
@@ -218,7 +218,7 @@ workflows:
             - python34
             - python35
             - python36
-            - php5
+            - php56
           filters:
             branches:
               only: master


### PR DESCRIPTION
Add PHP5 first. The unit tests are now having compatibility issues with PHP 7.*.
Note: A testing Docker image is built and pushed to Dockerhub:  @https://hub.docker.com/r/googleapis/php

TODO: Fix issues on PHP 7.

cc @landrito 