### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
         "google/gax": "^0.25"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/generated/php/google-longrunning-v1/tests/unit/GAX/LongRunning/MockOperationsImpl.php
+++ b/generated/php/google-longrunning-v1/tests/unit/GAX/LongRunning/MockOperationsImpl.php
@@ -49,7 +49,7 @@ use Google\Longrunning\OperationsGrpcClient;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class MockOperationsImpl extends OperationsGrpcClient


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump `PHPUnit` version to [`4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that contains this new `namespace`.