### PR TITLE
Allow smoke tests to be present in PHP

### DIFF
--- a/generated/php/google-cloud-pubsub-v1/tests/system/PubSub/V1/PublisherSmokeTest.php
+++ b/generated/php/google-cloud-pubsub-v1/tests/system/PubSub/V1/PublisherSmokeTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+namespace Google\Cloud\Tests\System\PubSub\V1;
+
+use Google\Cloud\PubSub\V1\PublisherClient;
+use Google\ApiCore\Testing\GeneratedTest;
+
+/**
+ * @group pub_sub
+ * @group grpc
+ */
+class PublisherSmokeTest extends GeneratedTest
+{
+    /**
+     * @test
+     */
+    public function listTopicsTest()
+    {
+        $projectId = getenv('PROJECT_ID');
+        if ($projectId === false) {
+            $this->fail('Environment variable PROJECT_ID must be set for smoke test');
+        }
+
+        $publisherClient = new PublisherClient();
+        $formattedProject = $publisherClient->projectName($projectId);
+        $publisherClient->listTopics($formattedProject);
+    }
+}

--- a/phpunit-system.xml.dist
+++ b/phpunit-system.xml.dist
@@ -3,7 +3,7 @@
          colors="true">
   <testsuites>
     <testsuite>
-      <directory>generated/php/*/tests/unit</directory>
+      <directory>generated/php/*/tests/system</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
- Allow smoke tests to be present by excluding them from normal test runs
- Add smoke test for pubsub
- Add system test config that can be used to run smoke tests

Smoke tests for other APIs can be added when those APIs are refreshed. This PR does not cause smoke tests to be run as part of api-client-staging CI, as I expect that this would cause too many failures at this point.