### PR TITLE
Regenerated Cloud Bigtable

### DIFF
--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClient.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClient.java
@@ -15,37 +15,52 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListAppProfilesPagedResponse;
+
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.AppProfile;
+import com.google.bigtable.admin.v2.AppProfileName;
 import com.google.bigtable.admin.v2.Cluster;
 import com.google.bigtable.admin.v2.ClusterName;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterMetadata;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceMetadata;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
-import com.google.bigtable.admin.v2.Instance.Type;
 import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
-import com.google.bigtable.admin.v2.LocationName;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
 import com.google.bigtable.admin.v2.ProjectName;
-import com.google.bigtable.admin.v2.StorageType;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
 import com.google.bigtable.admin.v2.UpdateClusterMetadata;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStub;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
@@ -460,43 +475,12 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    *   InstanceName name = InstanceName.of("[PROJECT]", "[INSTANCE]");
    *   String displayName = "";
    *   Instance.Type type = Instance.Type.TYPE_UNSPECIFIED;
-   *   Instance response = bigtableInstanceAdminClient.updateInstance(name, displayName, type);
-   * }
-   * </code></pre>
-   *
-   * @param name (`OutputOnly`) The unique name of the instance. Values are of the form
-   *     `projects/&lt;project&gt;/instances/[a-z][a-z0-9\\-]+[a-z0-9]`.
-   * @param displayName The descriptive name for this instance as it appears in UIs. Can be changed
-   *     at any time, but should be kept globally unique to avoid confusion.
-   * @param type The type of the instance. Defaults to `PRODUCTION`.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final Instance updateInstance(InstanceName name, String displayName, Instance.Type type) {
-
-    Instance request =
-        Instance.newBuilder()
-            .setNameWithInstanceName(name)
-            .setDisplayName(displayName)
-            .setType(type)
-            .build();
-    return updateInstance(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD
-  /**
-   * Updates an instance within a project.
-   *
-   * <p>Sample code:
-   *
-   * <pre><code>
-   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
-   *   InstanceName name = InstanceName.of("[PROJECT]", "[INSTANCE]");
-   *   String displayName = "";
-   *   Instance.Type type = Instance.Type.TYPE_UNSPECIFIED;
+   *   Map&lt;String, String&gt; labels = new HashMap&lt;&gt;();
    *   Instance request = Instance.newBuilder()
    *     .setNameWithInstanceName(name)
    *     .setDisplayName(displayName)
    *     .setType(type)
+   *     .putAllLabels(labels)
    *     .build();
    *   Instance response = bigtableInstanceAdminClient.updateInstance(request);
    * }
@@ -520,10 +504,12 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    *   InstanceName name = InstanceName.of("[PROJECT]", "[INSTANCE]");
    *   String displayName = "";
    *   Instance.Type type = Instance.Type.TYPE_UNSPECIFIED;
+   *   Map&lt;String, String&gt; labels = new HashMap&lt;&gt;();
    *   Instance request = Instance.newBuilder()
    *     .setNameWithInstanceName(name)
    *     .setDisplayName(displayName)
    *     .setType(type)
+   *     .putAllLabels(labels)
    *     .build();
    *   ApiFuture&lt;Instance&gt; future = bigtableInstanceAdminClient.updateInstanceCallable().futureCall(request);
    *   // Do something
@@ -533,6 +519,85 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    */
   public final UnaryCallable<Instance, Instance> updateInstanceCallable() {
     return stub.updateInstanceCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Partially updates an instance within a project.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   Instance instance = Instance.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   Operation response = bigtableInstanceAdminClient.partialUpdateInstance(instance, updateMask);
+   * }
+   * </code></pre>
+   *
+   * @param instance The Instance which will (partially) replace the current value.
+   * @param updateMask The subset of Instance fields which should be replaced. Must be explicitly
+   *     set.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation partialUpdateInstance(Instance instance, FieldMask updateMask) {
+
+    PartialUpdateInstanceRequest request =
+        PartialUpdateInstanceRequest.newBuilder()
+            .setInstance(instance)
+            .setUpdateMask(updateMask)
+            .build();
+    return partialUpdateInstance(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Partially updates an instance within a project.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   Instance instance = Instance.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   PartialUpdateInstanceRequest request = PartialUpdateInstanceRequest.newBuilder()
+   *     .setInstance(instance)
+   *     .setUpdateMask(updateMask)
+   *     .build();
+   *   Operation response = bigtableInstanceAdminClient.partialUpdateInstance(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation partialUpdateInstance(PartialUpdateInstanceRequest request) {
+    return partialUpdateInstanceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Partially updates an instance within a project.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   Instance instance = Instance.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   PartialUpdateInstanceRequest request = PartialUpdateInstanceRequest.newBuilder()
+   *     .setInstance(instance)
+   *     .setUpdateMask(updateMask)
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = bigtableInstanceAdminClient.partialUpdateInstanceCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<PartialUpdateInstanceRequest, Operation>
+      partialUpdateInstanceCallable() {
+    return stub.partialUpdateInstanceCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -869,53 +934,10 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    *   ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
    *   LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
    *   int serveNodes = 0;
-   *   StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
-   *   Cluster response = bigtableInstanceAdminClient.updateClusterAsync(name, location, serveNodes, defaultStorageType).get();
-   * }
-   * </code></pre>
-   *
-   * @param name (`OutputOnly`) The unique name of the cluster. Values are of the form
-   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/[a-z][-a-z0-9]&#42;`.
-   * @param location (`CreationOnly`) The location where this cluster's nodes and storage reside.
-   *     For best performance, clients should be located as close as possible to this cluster.
-   *     Currently only zones are supported, so values should be of the form
-   *     `projects/&lt;project&gt;/locations/&lt;zone&gt;`.
-   * @param serveNodes The number of nodes allocated to this cluster. More nodes enable higher
-   *     throughput and more consistent performance.
-   * @param defaultStorageType (`CreationOnly`) The type of storage used by this cluster to serve
-   *     its parent instance's tables, unless explicitly overridden.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final OperationFuture<Cluster, UpdateClusterMetadata> updateClusterAsync(
-      ClusterName name, LocationName location, int serveNodes, StorageType defaultStorageType) {
-
-    Cluster request =
-        Cluster.newBuilder()
-            .setNameWithClusterName(name)
-            .setLocationWithLocationName(location)
-            .setServeNodes(serveNodes)
-            .setDefaultStorageType(defaultStorageType)
-            .build();
-    return updateClusterAsync(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD
-  /**
-   * Updates a cluster within an instance.
-   *
-   * <p>Sample code:
-   *
-   * <pre><code>
-   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
-   *   ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
-   *   LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
-   *   int serveNodes = 0;
-   *   StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
    *   Cluster request = Cluster.newBuilder()
    *     .setNameWithClusterName(name)
    *     .setLocationWithLocationName(location)
    *     .setServeNodes(serveNodes)
-   *     .setDefaultStorageType(defaultStorageType)
    *     .build();
    *   Cluster response = bigtableInstanceAdminClient.updateClusterAsync(request).get();
    * }
@@ -939,12 +961,10 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    *   ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
    *   LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
    *   int serveNodes = 0;
-   *   StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
    *   Cluster request = Cluster.newBuilder()
    *     .setNameWithClusterName(name)
    *     .setLocationWithLocationName(location)
    *     .setServeNodes(serveNodes)
-   *     .setDefaultStorageType(defaultStorageType)
    *     .build();
    *   OperationFuture&lt;Operation&gt; future = bigtableInstanceAdminClient.updateClusterOperationCallable().futureCall(request);
    *   // Do something
@@ -968,12 +988,10 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    *   ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
    *   LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
    *   int serveNodes = 0;
-   *   StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
    *   Cluster request = Cluster.newBuilder()
    *     .setNameWithClusterName(name)
    *     .setLocationWithLocationName(location)
    *     .setServeNodes(serveNodes)
-   *     .setDefaultStorageType(defaultStorageType)
    *     .build();
    *   ApiFuture&lt;Operation&gt; future = bigtableInstanceAdminClient.updateClusterCallable().futureCall(request);
    *   // Do something
@@ -1052,6 +1070,779 @@ public class BigtableInstanceAdminClient implements BackgroundResource {
    */
   public final UnaryCallable<DeleteClusterRequest, Empty> deleteClusterCallable() {
     return stub.deleteClusterCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String appProfileId = "";
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   AppProfile response = bigtableInstanceAdminClient.createAppProfile(parent, appProfileId, appProfile);
+   * }
+   * </code></pre>
+   *
+   * @param parent The unique name of the instance in which to create the new app profile. Values
+   *     are of the form `projects/&lt;project&gt;/instances/&lt;instance&gt;`.
+   * @param appProfileId The ID to be used when referring to the new app profile within its
+   *     instance, e.g., just `myprofile` rather than
+   *     `projects/myproject/instances/myinstance/appProfiles/myprofile`.
+   * @param appProfile The app profile to be created. Fields marked `OutputOnly` will be ignored.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AppProfile createAppProfile(
+      InstanceName parent, String appProfileId, AppProfile appProfile) {
+
+    CreateAppProfileRequest request =
+        CreateAppProfileRequest.newBuilder()
+            .setParentWithInstanceName(parent)
+            .setAppProfileId(appProfileId)
+            .setAppProfile(appProfile)
+            .build();
+    return createAppProfile(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String appProfileId = "";
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   CreateAppProfileRequest request = CreateAppProfileRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .setAppProfileId(appProfileId)
+   *     .setAppProfile(appProfile)
+   *     .build();
+   *   AppProfile response = bigtableInstanceAdminClient.createAppProfile(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AppProfile createAppProfile(CreateAppProfileRequest request) {
+    return createAppProfileCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String appProfileId = "";
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   CreateAppProfileRequest request = CreateAppProfileRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .setAppProfileId(appProfileId)
+   *     .setAppProfile(appProfile)
+   *     .build();
+   *   ApiFuture&lt;AppProfile&gt; future = bigtableInstanceAdminClient.createAppProfileCallable().futureCall(request);
+   *   // Do something
+   *   AppProfile response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateAppProfileRequest, AppProfile> createAppProfileCallable() {
+    return stub.createAppProfileCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets information about an app profile.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   AppProfile response = bigtableInstanceAdminClient.getAppProfile(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the requested app profile. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/appProfiles/&lt;app_profile&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AppProfile getAppProfile(AppProfileName name) {
+
+    GetAppProfileRequest request =
+        GetAppProfileRequest.newBuilder().setNameWithAppProfileName(name).build();
+    return getAppProfile(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets information about an app profile.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   GetAppProfileRequest request = GetAppProfileRequest.newBuilder()
+   *     .setNameWithAppProfileName(name)
+   *     .build();
+   *   AppProfile response = bigtableInstanceAdminClient.getAppProfile(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  private final AppProfile getAppProfile(GetAppProfileRequest request) {
+    return getAppProfileCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets information about an app profile.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   GetAppProfileRequest request = GetAppProfileRequest.newBuilder()
+   *     .setNameWithAppProfileName(name)
+   *     .build();
+   *   ApiFuture&lt;AppProfile&gt; future = bigtableInstanceAdminClient.getAppProfileCallable().futureCall(request);
+   *   // Do something
+   *   AppProfile response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetAppProfileRequest, AppProfile> getAppProfileCallable() {
+    return stub.getAppProfileCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists information about app profiles in an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   for (AppProfile element : bigtableInstanceAdminClient.listAppProfiles(parent).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param parent The unique name of the instance for which a list of app profiles is requested.
+   *     Values are of the form `projects/&lt;project&gt;/instances/&lt;instance&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListAppProfilesPagedResponse listAppProfiles(InstanceName parent) {
+    ListAppProfilesRequest request =
+        ListAppProfilesRequest.newBuilder().setParentWithInstanceName(parent).build();
+    return listAppProfiles(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists information about app profiles in an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   ListAppProfilesRequest request = ListAppProfilesRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .build();
+   *   for (AppProfile element : bigtableInstanceAdminClient.listAppProfiles(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListAppProfilesPagedResponse listAppProfiles(ListAppProfilesRequest request) {
+    return listAppProfilesPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists information about app profiles in an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   ListAppProfilesRequest request = ListAppProfilesRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .build();
+   *   ApiFuture&lt;ListAppProfilesPagedResponse&gt; future = bigtableInstanceAdminClient.listAppProfilesPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (AppProfile element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListAppProfilesRequest, ListAppProfilesPagedResponse>
+      listAppProfilesPagedCallable() {
+    return stub.listAppProfilesPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists information about app profiles in an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   ListAppProfilesRequest request = ListAppProfilesRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .build();
+   *   while (true) {
+   *     ListAppProfilesResponse response = bigtableInstanceAdminClient.listAppProfilesCallable().call(request);
+   *     for (AppProfile element : response.getAppProfilesList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListAppProfilesRequest, ListAppProfilesResponse>
+      listAppProfilesCallable() {
+    return stub.listAppProfilesCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Updates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   Operation response = bigtableInstanceAdminClient.updateAppProfile(appProfile, updateMask);
+   * }
+   * </code></pre>
+   *
+   * @param appProfile The app profile which will (partially) replace the current value.
+   * @param updateMask The subset of app profile fields which should be replaced. If unset, all
+   *     fields will be replaced.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation updateAppProfile(AppProfile appProfile, FieldMask updateMask) {
+
+    UpdateAppProfileRequest request =
+        UpdateAppProfileRequest.newBuilder()
+            .setAppProfile(appProfile)
+            .setUpdateMask(updateMask)
+            .build();
+    return updateAppProfile(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Updates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   UpdateAppProfileRequest request = UpdateAppProfileRequest.newBuilder()
+   *     .setAppProfile(appProfile)
+   *     .setUpdateMask(updateMask)
+   *     .build();
+   *   Operation response = bigtableInstanceAdminClient.updateAppProfile(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation updateAppProfile(UpdateAppProfileRequest request) {
+    return updateAppProfileCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Updates an app profile within an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfile appProfile = AppProfile.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   UpdateAppProfileRequest request = UpdateAppProfileRequest.newBuilder()
+   *     .setAppProfile(appProfile)
+   *     .setUpdateMask(updateMask)
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = bigtableInstanceAdminClient.updateAppProfileCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<UpdateAppProfileRequest, Operation> updateAppProfileCallable() {
+    return stub.updateAppProfileCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Deletes an app profile from an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   bigtableInstanceAdminClient.deleteAppProfile(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the app profile to be deleted. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/appProfiles/&lt;app_profile&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteAppProfile(AppProfileName name) {
+
+    DeleteAppProfileRequest request =
+        DeleteAppProfileRequest.newBuilder().setNameWithAppProfileName(name).build();
+    deleteAppProfile(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Deletes an app profile from an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   boolean ignoreWarnings = false;
+   *   DeleteAppProfileRequest request = DeleteAppProfileRequest.newBuilder()
+   *     .setNameWithAppProfileName(name)
+   *     .setIgnoreWarnings(ignoreWarnings)
+   *     .build();
+   *   bigtableInstanceAdminClient.deleteAppProfile(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteAppProfile(DeleteAppProfileRequest request) {
+    deleteAppProfileCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Deletes an app profile from an instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+   *   boolean ignoreWarnings = false;
+   *   DeleteAppProfileRequest request = DeleteAppProfileRequest.newBuilder()
+   *     .setNameWithAppProfileName(name)
+   *     .setIgnoreWarnings(ignoreWarnings)
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = bigtableInstanceAdminClient.deleteAppProfileCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<DeleteAppProfileRequest, Empty> deleteAppProfileCallable() {
+    return stub.deleteAppProfileCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets the access control policy for an instance resource. Returns an empty policy if an
+   * instance exists but does not have a policy set.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   Policy response = bigtableInstanceAdminClient.getIamPolicy(formattedResource);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource for which the policy is being requested. `resource` is
+   *     usually specified as a path. For example, a Project resource is specified as
+   *     `projects/{project}`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Policy getIamPolicy(String resource) {
+
+    GetIamPolicyRequest request = GetIamPolicyRequest.newBuilder().setResource(resource).build();
+    return getIamPolicy(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets the access control policy for an instance resource. Returns an empty policy if an
+   * instance exists but does not have a policy set.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   GetIamPolicyRequest request = GetIamPolicyRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .build();
+   *   Policy response = bigtableInstanceAdminClient.getIamPolicy(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  private final Policy getIamPolicy(GetIamPolicyRequest request) {
+    return getIamPolicyCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets the access control policy for an instance resource. Returns an empty policy if an
+   * instance exists but does not have a policy set.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   GetIamPolicyRequest request = GetIamPolicyRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .build();
+   *   ApiFuture&lt;Policy&gt; future = bigtableInstanceAdminClient.getIamPolicyCallable().futureCall(request);
+   *   // Do something
+   *   Policy response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetIamPolicyRequest, Policy> getIamPolicyCallable() {
+    return stub.getIamPolicyCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Sets the access control policy on an instance resource. Replaces any existing policy.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   Policy policy = Policy.newBuilder().build();
+   *   Policy response = bigtableInstanceAdminClient.setIamPolicy(formattedResource, policy);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource for which the policy is being specified. `resource` is
+   *     usually specified as a path. For example, a Project resource is specified as
+   *     `projects/{project}`.
+   * @param policy REQUIRED: The complete policy to be applied to the `resource`. The size of the
+   *     policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Cloud
+   *     Platform services (such as Projects) might reject them.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Policy setIamPolicy(String resource, Policy policy) {
+
+    SetIamPolicyRequest request =
+        SetIamPolicyRequest.newBuilder().setResource(resource).setPolicy(policy).build();
+    return setIamPolicy(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Sets the access control policy on an instance resource. Replaces any existing policy.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   Policy policy = Policy.newBuilder().build();
+   *   SetIamPolicyRequest request = SetIamPolicyRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setPolicy(policy)
+   *     .build();
+   *   Policy response = bigtableInstanceAdminClient.setIamPolicy(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Policy setIamPolicy(SetIamPolicyRequest request) {
+    return setIamPolicyCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Sets the access control policy on an instance resource. Replaces any existing policy.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   Policy policy = Policy.newBuilder().build();
+   *   SetIamPolicyRequest request = SetIamPolicyRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setPolicy(policy)
+   *     .build();
+   *   ApiFuture&lt;Policy&gt; future = bigtableInstanceAdminClient.setIamPolicyCallable().futureCall(request);
+   *   // Do something
+   *   Policy response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    return stub.setIamPolicyCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Returns permissions that the caller has on the specified instance resource.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   List&lt;String&gt; permissions = new ArrayList&lt;&gt;();
+   *   TestIamPermissionsResponse response = bigtableInstanceAdminClient.testIamPermissions(formattedResource, permissions);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource for which the policy detail is being requested.
+   *     `resource` is usually specified as a path. For example, a Project resource is specified as
+   *     `projects/{project}`.
+   * @param permissions The set of permissions to check for the `resource`. Permissions with
+   *     wildcards (such as '&#42;' or 'storage.&#42;') are not allowed. For more information see
+   *     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestIamPermissionsResponse testIamPermissions(
+      String resource, List<String> permissions) {
+
+    TestIamPermissionsRequest request =
+        TestIamPermissionsRequest.newBuilder()
+            .setResource(resource)
+            .addAllPermissions(permissions)
+            .build();
+    return testIamPermissions(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Returns permissions that the caller has on the specified instance resource.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   List&lt;String&gt; permissions = new ArrayList&lt;&gt;();
+   *   TestIamPermissionsRequest request = TestIamPermissionsRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .addAllPermissions(permissions)
+   *     .build();
+   *   TestIamPermissionsResponse response = bigtableInstanceAdminClient.testIamPermissions(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestIamPermissionsResponse testIamPermissions(TestIamPermissionsRequest request) {
+    return testIamPermissionsCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable instance level permissions. This feature is
+   * not currently available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Returns permissions that the caller has on the specified instance resource.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableInstanceAdminClient bigtableInstanceAdminClient = BigtableInstanceAdminClient.create()) {
+   *   String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+   *   List&lt;String&gt; permissions = new ArrayList&lt;&gt;();
+   *   TestIamPermissionsRequest request = TestIamPermissionsRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .addAllPermissions(permissions)
+   *     .build();
+   *   ApiFuture&lt;TestIamPermissionsResponse&gt; future = bigtableInstanceAdminClient.testIamPermissionsCallable().futureCall(request);
+   *   // Do something
+   *   TestIamPermissionsResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    return stub.testIamPermissionsCallable();
   }
 
   @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
@@ -15,39 +15,56 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListAppProfilesPagedResponse;
+
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
-import com.google.api.gax.grpc.GrpcExtraHeaderData;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.grpc.ProtoOperationTransformers;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ClientSettings;
 import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterMetadata;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceMetadata;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
 import com.google.bigtable.admin.v2.UpdateClusterMetadata;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStub;
 import com.google.cloud.bigtable.admin.v2.stub.GrpcBigtableInstanceAdminStub;
@@ -55,6 +72,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import java.io.IOException;
@@ -105,15 +127,6 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
           .add("https://www.googleapis.com/auth/cloud-platform.read-only")
           .build();
 
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE =
-      "/com/google/cloud/bigtable/admin/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
-
   private final UnaryCallSettings<CreateInstanceRequest, Operation> createInstanceSettings;
   private final OperationCallSettings<CreateInstanceRequest, Instance, CreateInstanceMetadata>
       createInstanceOperationSettings;
@@ -121,6 +134,8 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
   private final UnaryCallSettings<ListInstancesRequest, ListInstancesResponse>
       listInstancesSettings;
   private final UnaryCallSettings<Instance, Instance> updateInstanceSettings;
+  private final UnaryCallSettings<PartialUpdateInstanceRequest, Operation>
+      partialUpdateInstanceSettings;
   private final UnaryCallSettings<DeleteInstanceRequest, Empty> deleteInstanceSettings;
   private final UnaryCallSettings<CreateClusterRequest, Operation> createClusterSettings;
   private final OperationCallSettings<CreateClusterRequest, Cluster, CreateClusterMetadata>
@@ -131,6 +146,17 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
   private final OperationCallSettings<Cluster, Cluster, UpdateClusterMetadata>
       updateClusterOperationSettings;
   private final UnaryCallSettings<DeleteClusterRequest, Empty> deleteClusterSettings;
+  private final UnaryCallSettings<CreateAppProfileRequest, AppProfile> createAppProfileSettings;
+  private final UnaryCallSettings<GetAppProfileRequest, AppProfile> getAppProfileSettings;
+  private final PagedCallSettings<
+          ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>
+      listAppProfilesSettings;
+  private final UnaryCallSettings<UpdateAppProfileRequest, Operation> updateAppProfileSettings;
+  private final UnaryCallSettings<DeleteAppProfileRequest, Empty> deleteAppProfileSettings;
+  private final UnaryCallSettings<GetIamPolicyRequest, Policy> getIamPolicySettings;
+  private final UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings;
+  private final UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsSettings;
 
   /** Returns the object with the settings used for calls to createInstance. */
   public UnaryCallSettings<CreateInstanceRequest, Operation> createInstanceSettings() {
@@ -156,6 +182,12 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
   /** Returns the object with the settings used for calls to updateInstance. */
   public UnaryCallSettings<Instance, Instance> updateInstanceSettings() {
     return updateInstanceSettings;
+  }
+
+  /** Returns the object with the settings used for calls to partialUpdateInstance. */
+  public UnaryCallSettings<PartialUpdateInstanceRequest, Operation>
+      partialUpdateInstanceSettings() {
+    return partialUpdateInstanceSettings;
   }
 
   /** Returns the object with the settings used for calls to deleteInstance. */
@@ -198,6 +230,49 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
   /** Returns the object with the settings used for calls to deleteCluster. */
   public UnaryCallSettings<DeleteClusterRequest, Empty> deleteClusterSettings() {
     return deleteClusterSettings;
+  }
+
+  /** Returns the object with the settings used for calls to createAppProfile. */
+  public UnaryCallSettings<CreateAppProfileRequest, AppProfile> createAppProfileSettings() {
+    return createAppProfileSettings;
+  }
+
+  /** Returns the object with the settings used for calls to getAppProfile. */
+  public UnaryCallSettings<GetAppProfileRequest, AppProfile> getAppProfileSettings() {
+    return getAppProfileSettings;
+  }
+
+  /** Returns the object with the settings used for calls to listAppProfiles. */
+  public PagedCallSettings<
+          ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>
+      listAppProfilesSettings() {
+    return listAppProfilesSettings;
+  }
+
+  /** Returns the object with the settings used for calls to updateAppProfile. */
+  public UnaryCallSettings<UpdateAppProfileRequest, Operation> updateAppProfileSettings() {
+    return updateAppProfileSettings;
+  }
+
+  /** Returns the object with the settings used for calls to deleteAppProfile. */
+  public UnaryCallSettings<DeleteAppProfileRequest, Empty> deleteAppProfileSettings() {
+    return deleteAppProfileSettings;
+  }
+
+  /** Returns the object with the settings used for calls to getIamPolicy. */
+  public UnaryCallSettings<GetIamPolicyRequest, Policy> getIamPolicySettings() {
+    return getIamPolicySettings;
+  }
+
+  /** Returns the object with the settings used for calls to setIamPolicy. */
+  public UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+    return setIamPolicySettings;
+  }
+
+  /** Returns the object with the settings used for calls to testIamPermissions. */
+  public UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsSettings() {
+    return testIamPermissionsSettings;
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
@@ -244,19 +319,10 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData());
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion =
-          PropertiesProvider.loadProperty(
-              BigtableInstanceAdminSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+        .setGeneratedLibToken(
+            "gapic", GaxProperties.getLibraryVersion(BigtableInstanceAdminSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /** Returns a new builder for this class. */
@@ -274,7 +340,7 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     return new Builder(this);
   }
 
-  private BigtableInstanceAdminSettings(Builder settingsBuilder) throws IOException {
+  protected BigtableInstanceAdminSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
 
     createInstanceSettings = settingsBuilder.createInstanceSettings().build();
@@ -282,6 +348,7 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     getInstanceSettings = settingsBuilder.getInstanceSettings().build();
     listInstancesSettings = settingsBuilder.listInstancesSettings().build();
     updateInstanceSettings = settingsBuilder.updateInstanceSettings().build();
+    partialUpdateInstanceSettings = settingsBuilder.partialUpdateInstanceSettings().build();
     deleteInstanceSettings = settingsBuilder.deleteInstanceSettings().build();
     createClusterSettings = settingsBuilder.createClusterSettings().build();
     createClusterOperationSettings = settingsBuilder.createClusterOperationSettings().build();
@@ -290,7 +357,71 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     updateClusterSettings = settingsBuilder.updateClusterSettings().build();
     updateClusterOperationSettings = settingsBuilder.updateClusterOperationSettings().build();
     deleteClusterSettings = settingsBuilder.deleteClusterSettings().build();
+    createAppProfileSettings = settingsBuilder.createAppProfileSettings().build();
+    getAppProfileSettings = settingsBuilder.getAppProfileSettings().build();
+    listAppProfilesSettings = settingsBuilder.listAppProfilesSettings().build();
+    updateAppProfileSettings = settingsBuilder.updateAppProfileSettings().build();
+    deleteAppProfileSettings = settingsBuilder.deleteAppProfileSettings().build();
+    getIamPolicySettings = settingsBuilder.getIamPolicySettings().build();
+    setIamPolicySettings = settingsBuilder.setIamPolicySettings().build();
+    testIamPermissionsSettings = settingsBuilder.testIamPermissionsSettings().build();
   }
+
+  private static final PagedListDescriptor<
+          ListAppProfilesRequest, ListAppProfilesResponse, AppProfile>
+      LIST_APP_PROFILES_PAGE_STR_DESC =
+          new PagedListDescriptor<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public ListAppProfilesRequest injectToken(
+                ListAppProfilesRequest payload, String token) {
+              return ListAppProfilesRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public ListAppProfilesRequest injectPageSize(
+                ListAppProfilesRequest payload, int pageSize) {
+              throw new UnsupportedOperationException(
+                  "page size is not supported by this API method");
+            }
+
+            @Override
+            public Integer extractPageSize(ListAppProfilesRequest payload) {
+              throw new UnsupportedOperationException(
+                  "page size is not supported by this API method");
+            }
+
+            @Override
+            public String extractNextToken(ListAppProfilesResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<AppProfile> extractResources(ListAppProfilesResponse payload) {
+              return payload.getAppProfilesList();
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>
+      LIST_APP_PROFILES_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>() {
+            @Override
+            public ApiFuture<ListAppProfilesPagedResponse> getFuturePagedResponse(
+                UnaryCallable<ListAppProfilesRequest, ListAppProfilesResponse> callable,
+                ListAppProfilesRequest request,
+                ApiCallContext context,
+                ApiFuture<ListAppProfilesResponse> futureResponse) {
+              PageContext<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile> pageContext =
+                  PageContext.create(callable, LIST_APP_PROFILES_PAGE_STR_DESC, request, context);
+              return ListAppProfilesPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
 
   /** Builder for BigtableInstanceAdminSettings. */
   public static class Builder
@@ -306,6 +437,8 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     private final UnaryCallSettings.Builder<ListInstancesRequest, ListInstancesResponse>
         listInstancesSettings;
     private final UnaryCallSettings.Builder<Instance, Instance> updateInstanceSettings;
+    private final UnaryCallSettings.Builder<PartialUpdateInstanceRequest, Operation>
+        partialUpdateInstanceSettings;
     private final UnaryCallSettings.Builder<DeleteInstanceRequest, Empty> deleteInstanceSettings;
     private final UnaryCallSettings.Builder<CreateClusterRequest, Operation> createClusterSettings;
     private final OperationCallSettings.Builder<
@@ -318,6 +451,20 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     private final OperationCallSettings.Builder<Cluster, Cluster, UpdateClusterMetadata>
         updateClusterOperationSettings;
     private final UnaryCallSettings.Builder<DeleteClusterRequest, Empty> deleteClusterSettings;
+    private final UnaryCallSettings.Builder<CreateAppProfileRequest, AppProfile>
+        createAppProfileSettings;
+    private final UnaryCallSettings.Builder<GetAppProfileRequest, AppProfile> getAppProfileSettings;
+    private final PagedCallSettings.Builder<
+            ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>
+        listAppProfilesSettings;
+    private final UnaryCallSettings.Builder<UpdateAppProfileRequest, Operation>
+        updateAppProfileSettings;
+    private final UnaryCallSettings.Builder<DeleteAppProfileRequest, Empty>
+        deleteAppProfileSettings;
+    private final UnaryCallSettings.Builder<GetIamPolicyRequest, Policy> getIamPolicySettings;
+    private final UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings;
+    private final UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
         RETRYABLE_CODE_DEFINITIONS;
@@ -355,11 +502,11 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
-    private Builder() {
+    protected Builder() {
       this((ClientContext) null);
     }
 
-    private Builder(ClientContext clientContext) {
+    protected Builder(ClientContext clientContext) {
       super(clientContext);
 
       createInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -371,6 +518,8 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       listInstancesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       updateInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      partialUpdateInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       deleteInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -388,18 +537,43 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
 
       deleteClusterSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      createAppProfileSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getAppProfileSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      listAppProfilesSettings = PagedCallSettings.newBuilder(LIST_APP_PROFILES_PAGE_STR_FACT);
+
+      updateAppProfileSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      deleteAppProfileSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getIamPolicySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      setIamPolicySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      testIamPermissionsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               createInstanceSettings,
               getInstanceSettings,
               listInstancesSettings,
               updateInstanceSettings,
+              partialUpdateInstanceSettings,
               deleteInstanceSettings,
               createClusterSettings,
               getClusterSettings,
               listClustersSettings,
               updateClusterSettings,
-              deleteClusterSettings);
+              deleteClusterSettings,
+              createAppProfileSettings,
+              getAppProfileSettings,
+              listAppProfilesSettings,
+              updateAppProfileSettings,
+              deleteAppProfileSettings,
+              getIamPolicySettings,
+              setIamPolicySettings,
+              testIamPermissionsSettings);
 
       initDefaults(this);
     }
@@ -408,7 +582,7 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       Builder builder = new Builder((ClientContext) null);
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
       return initDefaults(builder);
     }
@@ -432,6 +606,11 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
 
       builder
           .updateInstanceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .partialUpdateInstanceSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
@@ -462,6 +641,46 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
 
       builder
           .deleteClusterSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .createAppProfileSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .getAppProfileSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .listAppProfilesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .updateAppProfileSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .deleteAppProfileSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .getIamPolicySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .setIamPolicySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .testIamPermissionsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
       builder
@@ -536,7 +755,7 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       return builder;
     }
 
-    private Builder(BigtableInstanceAdminSettings settings) {
+    protected Builder(BigtableInstanceAdminSettings settings) {
       super(settings);
 
       createInstanceSettings = settings.createInstanceSettings.toBuilder();
@@ -544,6 +763,7 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       getInstanceSettings = settings.getInstanceSettings.toBuilder();
       listInstancesSettings = settings.listInstancesSettings.toBuilder();
       updateInstanceSettings = settings.updateInstanceSettings.toBuilder();
+      partialUpdateInstanceSettings = settings.partialUpdateInstanceSettings.toBuilder();
       deleteInstanceSettings = settings.deleteInstanceSettings.toBuilder();
       createClusterSettings = settings.createClusterSettings.toBuilder();
       createClusterOperationSettings = settings.createClusterOperationSettings.toBuilder();
@@ -552,6 +772,14 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
       updateClusterSettings = settings.updateClusterSettings.toBuilder();
       updateClusterOperationSettings = settings.updateClusterOperationSettings.toBuilder();
       deleteClusterSettings = settings.deleteClusterSettings.toBuilder();
+      createAppProfileSettings = settings.createAppProfileSettings.toBuilder();
+      getAppProfileSettings = settings.getAppProfileSettings.toBuilder();
+      listAppProfilesSettings = settings.listAppProfilesSettings.toBuilder();
+      updateAppProfileSettings = settings.updateAppProfileSettings.toBuilder();
+      deleteAppProfileSettings = settings.deleteAppProfileSettings.toBuilder();
+      getIamPolicySettings = settings.getIamPolicySettings.toBuilder();
+      setIamPolicySettings = settings.setIamPolicySettings.toBuilder();
+      testIamPermissionsSettings = settings.testIamPermissionsSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -559,12 +787,21 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
               getInstanceSettings,
               listInstancesSettings,
               updateInstanceSettings,
+              partialUpdateInstanceSettings,
               deleteInstanceSettings,
               createClusterSettings,
               getClusterSettings,
               listClustersSettings,
               updateClusterSettings,
-              deleteClusterSettings);
+              deleteClusterSettings,
+              createAppProfileSettings,
+              getAppProfileSettings,
+              listAppProfilesSettings,
+              updateAppProfileSettings,
+              deleteAppProfileSettings,
+              getIamPolicySettings,
+              setIamPolicySettings,
+              testIamPermissionsSettings);
     }
 
     /**
@@ -603,6 +840,12 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     /** Returns the builder for the settings used for calls to updateInstance. */
     public UnaryCallSettings.Builder<Instance, Instance> updateInstanceSettings() {
       return updateInstanceSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to partialUpdateInstance. */
+    public UnaryCallSettings.Builder<PartialUpdateInstanceRequest, Operation>
+        partialUpdateInstanceSettings() {
+      return partialUpdateInstanceSettings;
     }
 
     /** Returns the builder for the settings used for calls to deleteInstance. */
@@ -646,6 +889,51 @@ public class BigtableInstanceAdminSettings extends ClientSettings<BigtableInstan
     /** Returns the builder for the settings used for calls to deleteCluster. */
     public UnaryCallSettings.Builder<DeleteClusterRequest, Empty> deleteClusterSettings() {
       return deleteClusterSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to createAppProfile. */
+    public UnaryCallSettings.Builder<CreateAppProfileRequest, AppProfile>
+        createAppProfileSettings() {
+      return createAppProfileSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to getAppProfile. */
+    public UnaryCallSettings.Builder<GetAppProfileRequest, AppProfile> getAppProfileSettings() {
+      return getAppProfileSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to listAppProfiles. */
+    public PagedCallSettings.Builder<
+            ListAppProfilesRequest, ListAppProfilesResponse, ListAppProfilesPagedResponse>
+        listAppProfilesSettings() {
+      return listAppProfilesSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to updateAppProfile. */
+    public UnaryCallSettings.Builder<UpdateAppProfileRequest, Operation>
+        updateAppProfileSettings() {
+      return updateAppProfileSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to deleteAppProfile. */
+    public UnaryCallSettings.Builder<DeleteAppProfileRequest, Empty> deleteAppProfileSettings() {
+      return deleteAppProfileSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to getIamPolicy. */
+    public UnaryCallSettings.Builder<GetIamPolicyRequest, Policy> getIamPolicySettings() {
+      return getIamPolicySettings;
+    }
+
+    /** Returns the builder for the settings used for calls to setIamPolicy. */
+    public UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+      return setIamPolicySettings;
+    }
+
+    /** Returns the builder for the settings used for calls to testIamPermissions. */
+    public UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsSettings() {
+      return testIamPermissionsSettings;
     }
 
     @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -15,24 +15,42 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListSnapshotsPagedResponse;
 import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListTablesPagedResponse;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.ClusterName;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
 import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotName;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.bigtable.admin.v2.Table;
 import com.google.bigtable.admin.v2.TableName;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStub;
-import com.google.protobuf.ByteString;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
@@ -115,6 +133,7 @@ import javax.annotation.Generated;
 public class BigtableTableAdminClient implements BackgroundResource {
   private final BigtableTableAdminSettings settings;
   private final BigtableTableAdminStub stub;
+  private final OperationsClient operationsClient;
 
   /** Constructs an instance of BigtableTableAdminClient with default settings. */
   public static final BigtableTableAdminClient create() throws IOException {
@@ -147,12 +166,14 @@ public class BigtableTableAdminClient implements BackgroundResource {
   protected BigtableTableAdminClient(BigtableTableAdminSettings settings) throws IOException {
     this.settings = settings;
     this.stub = settings.createStub();
+    this.operationsClient = OperationsClient.create(this.stub.getOperationsStub());
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   protected BigtableTableAdminClient(BigtableTableAdminStub stub) {
     this.settings = null;
     this.stub = stub;
+    this.operationsClient = OperationsClient.create(this.stub.getOperationsStub());
   }
 
   public final BigtableTableAdminSettings getSettings() {
@@ -162,6 +183,14 @@ public class BigtableTableAdminClient implements BackgroundResource {
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public BigtableTableAdminStub getStub() {
     return stub;
+  }
+
+  /**
+   * Returns the OperationsClient that can be used to query the status of a long-running operation
+   * returned by another API method call.
+   */
+  public final OperationsClient getOperationsClient() {
+    return operationsClient;
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -255,6 +284,149 @@ public class BigtableTableAdminClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new table from the specified snapshot. The target table must not exist. The
+   * snapshot and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String tableId = "";
+   *   String sourceSnapshot = "";
+   *   Table response = bigtableTableAdminClient.createTableFromSnapshotAsync(parent, tableId, sourceSnapshot).get();
+   * }
+   * </code></pre>
+   *
+   * @param parent The unique name of the instance in which to create the table. Values are of the
+   *     form `projects/&lt;project&gt;/instances/&lt;instance&gt;`.
+   * @param tableId The name by which the new table should be referred to within the parent
+   *     instance, e.g., `foobar` rather than `&lt;parent&gt;/tables/foobar`.
+   * @param sourceSnapshot The unique name of the snapshot from which to restore the table. The
+   *     snapshot and the table must be in the same instance. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/&lt;cluster&gt;/snapshots/&lt;snapshot&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Table, CreateTableFromSnapshotMetadata> createTableFromSnapshotAsync(
+      InstanceName parent, String tableId, String sourceSnapshot) {
+
+    CreateTableFromSnapshotRequest request =
+        CreateTableFromSnapshotRequest.newBuilder()
+            .setParentWithInstanceName(parent)
+            .setTableId(tableId)
+            .setSourceSnapshot(sourceSnapshot)
+            .build();
+    return createTableFromSnapshotAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new table from the specified snapshot. The target table must not exist. The
+   * snapshot and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String tableId = "";
+   *   String sourceSnapshot = "";
+   *   CreateTableFromSnapshotRequest request = CreateTableFromSnapshotRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .setTableId(tableId)
+   *     .setSourceSnapshot(sourceSnapshot)
+   *     .build();
+   *   Table response = bigtableTableAdminClient.createTableFromSnapshotAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Table, CreateTableFromSnapshotMetadata> createTableFromSnapshotAsync(
+      CreateTableFromSnapshotRequest request) {
+    return createTableFromSnapshotOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new table from the specified snapshot. The target table must not exist. The
+   * snapshot and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String tableId = "";
+   *   String sourceSnapshot = "";
+   *   CreateTableFromSnapshotRequest request = CreateTableFromSnapshotRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .setTableId(tableId)
+   *     .setSourceSnapshot(sourceSnapshot)
+   *     .build();
+   *   OperationFuture&lt;Operation&gt; future = bigtableTableAdminClient.createTableFromSnapshotOperationCallable().futureCall(request);
+   *   // Do something
+   *   Table response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final OperationCallable<
+          CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationCallable() {
+    return stub.createTableFromSnapshotOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new table from the specified snapshot. The target table must not exist. The
+   * snapshot and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+   *   String tableId = "";
+   *   String sourceSnapshot = "";
+   *   CreateTableFromSnapshotRequest request = CreateTableFromSnapshotRequest.newBuilder()
+   *     .setParentWithInstanceName(parent)
+   *     .setTableId(tableId)
+   *     .setSourceSnapshot(sourceSnapshot)
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = bigtableTableAdminClient.createTableFromSnapshotCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotCallable() {
+    return stub.createTableFromSnapshotCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * Lists all tables served from a specified instance.
    *
    * <p>Sample code:
@@ -299,7 +471,7 @@ public class BigtableTableAdminClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final ListTablesPagedResponse listTables(ListTablesRequest request) {
+  public final ListTablesPagedResponse listTables(ListTablesRequest request) {
     return listTablesPagedCallable().call(request);
   }
 
@@ -590,37 +762,9 @@ public class BigtableTableAdminClient implements BackgroundResource {
    *
    * <pre><code>
    * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
-   *   String formattedName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
-   *   ByteString rowKeyPrefix = ByteString.copyFromUtf8("");
-   *   bigtableTableAdminClient.dropRowRange(formattedName, rowKeyPrefix);
-   * }
-   * </code></pre>
-   *
-   * @param name The unique name of the table on which to drop a range of rows. Values are of the
-   *     form `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
-   * @param rowKeyPrefix Delete all rows that start with this row key prefix. Prefix cannot be zero
-   *     length.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final void dropRowRange(String name, ByteString rowKeyPrefix) {
-
-    DropRowRangeRequest request =
-        DropRowRangeRequest.newBuilder().setName(name).setRowKeyPrefix(rowKeyPrefix).build();
-    dropRowRange(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD
-  /**
-   * Permanently drop/delete a row range from a specified table. The request can specify whether to
-   * delete all rows in a table, or only those that match a particular prefix.
-   *
-   * <p>Sample code:
-   *
-   * <pre><code>
-   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
-   *   String formattedName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
-   *     .setName(formattedName)
+   *     .setNameWithTableName(name)
    *     .build();
    *   bigtableTableAdminClient.dropRowRange(request);
    * }
@@ -642,9 +786,9 @@ public class BigtableTableAdminClient implements BackgroundResource {
    *
    * <pre><code>
    * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
-   *   String formattedName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
-   *     .setName(formattedName)
+   *     .setNameWithTableName(name)
    *     .build();
    *   ApiFuture&lt;Void&gt; future = bigtableTableAdminClient.dropRowRangeCallable().futureCall(request);
    *   // Do something
@@ -654,6 +798,560 @@ public class BigtableTableAdminClient implements BackgroundResource {
    */
   public final UnaryCallable<DropRowRangeRequest, Empty> dropRowRangeCallable() {
     return stub.dropRowRangeCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Generates a consistency token for a Table, which can be used in CheckConsistency to check
+   * whether mutations to the table that finished before this call started have been replicated. The
+   * tokens will be available for 90 days.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   GenerateConsistencyTokenResponse response = bigtableTableAdminClient.generateConsistencyToken(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the Table for which to create a consistency token. Values are of
+   *     the form `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final GenerateConsistencyTokenResponse generateConsistencyToken(TableName name) {
+
+    GenerateConsistencyTokenRequest request =
+        GenerateConsistencyTokenRequest.newBuilder().setNameWithTableName(name).build();
+    return generateConsistencyToken(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Generates a consistency token for a Table, which can be used in CheckConsistency to check
+   * whether mutations to the table that finished before this call started have been replicated. The
+   * tokens will be available for 90 days.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   GenerateConsistencyTokenRequest request = GenerateConsistencyTokenRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .build();
+   *   GenerateConsistencyTokenResponse response = bigtableTableAdminClient.generateConsistencyToken(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  private final GenerateConsistencyTokenResponse generateConsistencyToken(
+      GenerateConsistencyTokenRequest request) {
+    return generateConsistencyTokenCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Generates a consistency token for a Table, which can be used in CheckConsistency to check
+   * whether mutations to the table that finished before this call started have been replicated. The
+   * tokens will be available for 90 days.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   GenerateConsistencyTokenRequest request = GenerateConsistencyTokenRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .build();
+   *   ApiFuture&lt;GenerateConsistencyTokenResponse&gt; future = bigtableTableAdminClient.generateConsistencyTokenCallable().futureCall(request);
+   *   // Do something
+   *   GenerateConsistencyTokenResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenCallable() {
+    return stub.generateConsistencyTokenCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Checks replication consistency based on a consistency token, that is, if replication has
+   * caught up based on the conditions specified in the token and the check request.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   String consistencyToken = "";
+   *   CheckConsistencyResponse response = bigtableTableAdminClient.checkConsistency(name, consistencyToken);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the Table for which to check replication consistency. Values are
+   *     of the form `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param consistencyToken The token created using GenerateConsistencyToken for the Table.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckConsistencyResponse checkConsistency(TableName name, String consistencyToken) {
+
+    CheckConsistencyRequest request =
+        CheckConsistencyRequest.newBuilder()
+            .setNameWithTableName(name)
+            .setConsistencyToken(consistencyToken)
+            .build();
+    return checkConsistency(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Checks replication consistency based on a consistency token, that is, if replication has
+   * caught up based on the conditions specified in the token and the check request.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   String consistencyToken = "";
+   *   CheckConsistencyRequest request = CheckConsistencyRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .setConsistencyToken(consistencyToken)
+   *     .build();
+   *   CheckConsistencyResponse response = bigtableTableAdminClient.checkConsistency(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckConsistencyResponse checkConsistency(CheckConsistencyRequest request) {
+    return checkConsistencyCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable replication. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Checks replication consistency based on a consistency token, that is, if replication has
+   * caught up based on the conditions specified in the token and the check request.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   String consistencyToken = "";
+   *   CheckConsistencyRequest request = CheckConsistencyRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .setConsistencyToken(consistencyToken)
+   *     .build();
+   *   ApiFuture&lt;CheckConsistencyResponse&gt; future = bigtableTableAdminClient.checkConsistencyCallable().futureCall(request);
+   *   // Do something
+   *   CheckConsistencyResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencyCallable() {
+    return stub.checkConsistencyCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new snapshot in the specified cluster from the specified source table. The cluster
+   * and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   String cluster = "";
+   *   String snapshotId = "";
+   *   String description = "";
+   *   SnapshotTableRequest request = SnapshotTableRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .setCluster(cluster)
+   *     .setSnapshotId(snapshotId)
+   *     .setDescription(description)
+   *     .build();
+   *   Operation response = bigtableTableAdminClient.snapshotTable(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation snapshotTable(SnapshotTableRequest request) {
+    return snapshotTableCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Creates a new snapshot in the specified cluster from the specified source table. The cluster
+   * and the table must be in the same instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   String cluster = "";
+   *   String snapshotId = "";
+   *   String description = "";
+   *   SnapshotTableRequest request = SnapshotTableRequest.newBuilder()
+   *     .setNameWithTableName(name)
+   *     .setCluster(cluster)
+   *     .setSnapshotId(snapshotId)
+   *     .setDescription(description)
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = bigtableTableAdminClient.snapshotTableCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<SnapshotTableRequest, Operation> snapshotTableCallable() {
+    return stub.snapshotTableCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets metadata information about the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   Snapshot response = bigtableTableAdminClient.getSnapshot(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the requested snapshot. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/&lt;cluster&gt;/snapshots/&lt;snapshot&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Snapshot getSnapshot(SnapshotName name) {
+
+    GetSnapshotRequest request =
+        GetSnapshotRequest.newBuilder().setNameWithSnapshotName(name).build();
+    return getSnapshot(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets metadata information about the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   GetSnapshotRequest request = GetSnapshotRequest.newBuilder()
+   *     .setNameWithSnapshotName(name)
+   *     .build();
+   *   Snapshot response = bigtableTableAdminClient.getSnapshot(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  private final Snapshot getSnapshot(GetSnapshotRequest request) {
+    return getSnapshotCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Gets metadata information about the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   GetSnapshotRequest request = GetSnapshotRequest.newBuilder()
+   *     .setNameWithSnapshotName(name)
+   *     .build();
+   *   ApiFuture&lt;Snapshot&gt; future = bigtableTableAdminClient.getSnapshotCallable().futureCall(request);
+   *   // Do something
+   *   Snapshot response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetSnapshotRequest, Snapshot> getSnapshotCallable() {
+    return stub.getSnapshotCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists all snapshots associated with the specified cluster.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+   *   for (Snapshot element : bigtableTableAdminClient.listSnapshots(parent).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param parent The unique name of the cluster for which snapshots should be listed. Values are
+   *     of the form `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/&lt;cluster&gt;`.
+   *     Use `&lt;cluster&gt; = '-'` to list snapshots for all clusters in an instance, e.g.,
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/-`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListSnapshotsPagedResponse listSnapshots(ClusterName parent) {
+    ListSnapshotsRequest request =
+        ListSnapshotsRequest.newBuilder().setParentWithClusterName(parent).build();
+    return listSnapshots(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists all snapshots associated with the specified cluster.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+   *   ListSnapshotsRequest request = ListSnapshotsRequest.newBuilder()
+   *     .setParentWithClusterName(parent)
+   *     .build();
+   *   for (Snapshot element : bigtableTableAdminClient.listSnapshots(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListSnapshotsPagedResponse listSnapshots(ListSnapshotsRequest request) {
+    return listSnapshotsPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists all snapshots associated with the specified cluster.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+   *   ListSnapshotsRequest request = ListSnapshotsRequest.newBuilder()
+   *     .setParentWithClusterName(parent)
+   *     .build();
+   *   ApiFuture&lt;ListSnapshotsPagedResponse&gt; future = bigtableTableAdminClient.listSnapshotsPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (Snapshot element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListSnapshotsRequest, ListSnapshotsPagedResponse>
+      listSnapshotsPagedCallable() {
+    return stub.listSnapshotsPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Lists all snapshots associated with the specified cluster.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+   *   ListSnapshotsRequest request = ListSnapshotsRequest.newBuilder()
+   *     .setParentWithClusterName(parent)
+   *     .build();
+   *   while (true) {
+   *     ListSnapshotsResponse response = bigtableTableAdminClient.listSnapshotsCallable().call(request);
+   *     for (Snapshot element : response.getSnapshotsList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListSnapshotsRequest, ListSnapshotsResponse> listSnapshotsCallable() {
+    return stub.listSnapshotsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Permanently deletes the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   bigtableTableAdminClient.deleteSnapshot(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The unique name of the snapshot to be deleted. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/clusters/&lt;cluster&gt;/snapshots/&lt;snapshot&gt;`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteSnapshot(SnapshotName name) {
+
+    DeleteSnapshotRequest request =
+        DeleteSnapshotRequest.newBuilder().setNameWithSnapshotName(name).build();
+    deleteSnapshot(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Permanently deletes the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   DeleteSnapshotRequest request = DeleteSnapshotRequest.newBuilder()
+   *     .setNameWithSnapshotName(name)
+   *     .build();
+   *   bigtableTableAdminClient.deleteSnapshot(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  private final void deleteSnapshot(DeleteSnapshotRequest request) {
+    deleteSnapshotCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * This is a private alpha release of Cloud Bigtable snapshots. This feature is not currently
+   * available to most Cloud Bigtable customers. This feature might be changed in
+   * backward-incompatible ways and is not recommended for production use. It is not subject to any
+   * SLA or deprecation policy.
+   *
+   * <p>Permanently deletes the specified snapshot.
+   *
+   * <p>Sample code:
+   *
+   * <pre><code>
+   * try (BigtableTableAdminClient bigtableTableAdminClient = BigtableTableAdminClient.create()) {
+   *   SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+   *   DeleteSnapshotRequest request = DeleteSnapshotRequest.newBuilder()
+   *     .setNameWithSnapshotName(name)
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = bigtableTableAdminClient.deleteSnapshotCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<DeleteSnapshotRequest, Empty> deleteSnapshotCallable() {
+    return stub.deleteSnapshotCallable();
   }
 
   @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
@@ -15,22 +15,27 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListSnapshotsPagedResponse;
 import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListTablesPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
-import com.google.api.gax.grpc.GrpcExtraHeaderData;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.grpc.ProtoOperationTransformers;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.PagedListDescriptor;
@@ -39,13 +44,25 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStub;
 import com.google.cloud.bigtable.admin.v2.stub.GrpcBigtableTableAdminStub;
@@ -53,6 +70,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
@@ -102,26 +120,45 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
           .add("https://www.googleapis.com/auth/cloud-platform.read-only")
           .build();
 
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE =
-      "/com/google/cloud/bigtable/admin/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
-
   private final UnaryCallSettings<CreateTableRequest, Table> createTableSettings;
+  private final UnaryCallSettings<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotSettings;
+  private final OperationCallSettings<
+          CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationSettings;
   private final PagedCallSettings<ListTablesRequest, ListTablesResponse, ListTablesPagedResponse>
       listTablesSettings;
   private final UnaryCallSettings<GetTableRequest, Table> getTableSettings;
   private final UnaryCallSettings<DeleteTableRequest, Empty> deleteTableSettings;
   private final UnaryCallSettings<ModifyColumnFamiliesRequest, Table> modifyColumnFamiliesSettings;
   private final UnaryCallSettings<DropRowRangeRequest, Empty> dropRowRangeSettings;
+  private final UnaryCallSettings<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenSettings;
+  private final UnaryCallSettings<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencySettings;
+  private final UnaryCallSettings<SnapshotTableRequest, Operation> snapshotTableSettings;
+  private final UnaryCallSettings<GetSnapshotRequest, Snapshot> getSnapshotSettings;
+  private final PagedCallSettings<
+          ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>
+      listSnapshotsSettings;
+  private final UnaryCallSettings<DeleteSnapshotRequest, Empty> deleteSnapshotSettings;
 
   /** Returns the object with the settings used for calls to createTable. */
   public UnaryCallSettings<CreateTableRequest, Table> createTableSettings() {
     return createTableSettings;
+  }
+
+  /** Returns the object with the settings used for calls to createTableFromSnapshot. */
+  public UnaryCallSettings<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotSettings() {
+    return createTableFromSnapshotSettings;
+  }
+
+  /** Returns the object with the settings used for calls to createTableFromSnapshot. */
+  public OperationCallSettings<
+          CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationSettings() {
+    return createTableFromSnapshotOperationSettings;
   }
 
   /** Returns the object with the settings used for calls to listTables. */
@@ -148,6 +185,39 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
   /** Returns the object with the settings used for calls to dropRowRange. */
   public UnaryCallSettings<DropRowRangeRequest, Empty> dropRowRangeSettings() {
     return dropRowRangeSettings;
+  }
+
+  /** Returns the object with the settings used for calls to generateConsistencyToken. */
+  public UnaryCallSettings<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenSettings() {
+    return generateConsistencyTokenSettings;
+  }
+
+  /** Returns the object with the settings used for calls to checkConsistency. */
+  public UnaryCallSettings<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencySettings() {
+    return checkConsistencySettings;
+  }
+
+  /** Returns the object with the settings used for calls to snapshotTable. */
+  public UnaryCallSettings<SnapshotTableRequest, Operation> snapshotTableSettings() {
+    return snapshotTableSettings;
+  }
+
+  /** Returns the object with the settings used for calls to getSnapshot. */
+  public UnaryCallSettings<GetSnapshotRequest, Snapshot> getSnapshotSettings() {
+    return getSnapshotSettings;
+  }
+
+  /** Returns the object with the settings used for calls to listSnapshots. */
+  public PagedCallSettings<ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>
+      listSnapshotsSettings() {
+    return listSnapshotsSettings;
+  }
+
+  /** Returns the object with the settings used for calls to deleteSnapshot. */
+  public UnaryCallSettings<DeleteSnapshotRequest, Empty> deleteSnapshotSettings() {
+    return deleteSnapshotSettings;
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
@@ -194,19 +264,10 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData());
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion =
-          PropertiesProvider.loadProperty(
-              BigtableTableAdminSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+        .setGeneratedLibToken(
+            "gapic", GaxProperties.getLibraryVersion(BigtableTableAdminSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /** Returns a new builder for this class. */
@@ -224,15 +285,24 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
     return new Builder(this);
   }
 
-  private BigtableTableAdminSettings(Builder settingsBuilder) throws IOException {
+  protected BigtableTableAdminSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
 
     createTableSettings = settingsBuilder.createTableSettings().build();
+    createTableFromSnapshotSettings = settingsBuilder.createTableFromSnapshotSettings().build();
+    createTableFromSnapshotOperationSettings =
+        settingsBuilder.createTableFromSnapshotOperationSettings().build();
     listTablesSettings = settingsBuilder.listTablesSettings().build();
     getTableSettings = settingsBuilder.getTableSettings().build();
     deleteTableSettings = settingsBuilder.deleteTableSettings().build();
     modifyColumnFamiliesSettings = settingsBuilder.modifyColumnFamiliesSettings().build();
     dropRowRangeSettings = settingsBuilder.dropRowRangeSettings().build();
+    generateConsistencyTokenSettings = settingsBuilder.generateConsistencyTokenSettings().build();
+    checkConsistencySettings = settingsBuilder.checkConsistencySettings().build();
+    snapshotTableSettings = settingsBuilder.snapshotTableSettings().build();
+    getSnapshotSettings = settingsBuilder.getSnapshotSettings().build();
+    listSnapshotsSettings = settingsBuilder.listSnapshotsSettings().build();
+    deleteSnapshotSettings = settingsBuilder.deleteSnapshotSettings().build();
   }
 
   private static final PagedListDescriptor<ListTablesRequest, ListTablesResponse, Table>
@@ -271,6 +341,40 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
             }
           };
 
+  private static final PagedListDescriptor<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot>
+      LIST_SNAPSHOTS_PAGE_STR_DESC =
+          new PagedListDescriptor<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public ListSnapshotsRequest injectToken(ListSnapshotsRequest payload, String token) {
+              return ListSnapshotsRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public ListSnapshotsRequest injectPageSize(ListSnapshotsRequest payload, int pageSize) {
+              return ListSnapshotsRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(ListSnapshotsRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(ListSnapshotsResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<Snapshot> extractResources(ListSnapshotsResponse payload) {
+              return payload.getSnapshotsList();
+            }
+          };
+
   private static final PagedListResponseFactory<
           ListTablesRequest, ListTablesResponse, ListTablesPagedResponse>
       LIST_TABLES_PAGE_STR_FACT =
@@ -288,11 +392,33 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
             }
           };
 
+  private static final PagedListResponseFactory<
+          ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>
+      LIST_SNAPSHOTS_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>() {
+            @Override
+            public ApiFuture<ListSnapshotsPagedResponse> getFuturePagedResponse(
+                UnaryCallable<ListSnapshotsRequest, ListSnapshotsResponse> callable,
+                ListSnapshotsRequest request,
+                ApiCallContext context,
+                ApiFuture<ListSnapshotsResponse> futureResponse) {
+              PageContext<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot> pageContext =
+                  PageContext.create(callable, LIST_SNAPSHOTS_PAGE_STR_DESC, request, context);
+              return ListSnapshotsPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
+
   /** Builder for BigtableTableAdminSettings. */
   public static class Builder extends ClientSettings.Builder<BigtableTableAdminSettings, Builder> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<CreateTableRequest, Table> createTableSettings;
+    private final UnaryCallSettings.Builder<CreateTableFromSnapshotRequest, Operation>
+        createTableFromSnapshotSettings;
+    private final OperationCallSettings.Builder<
+            CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+        createTableFromSnapshotOperationSettings;
     private final PagedCallSettings.Builder<
             ListTablesRequest, ListTablesResponse, ListTablesPagedResponse>
         listTablesSettings;
@@ -301,6 +427,17 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
     private final UnaryCallSettings.Builder<ModifyColumnFamiliesRequest, Table>
         modifyColumnFamiliesSettings;
     private final UnaryCallSettings.Builder<DropRowRangeRequest, Empty> dropRowRangeSettings;
+    private final UnaryCallSettings.Builder<
+            GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+        generateConsistencyTokenSettings;
+    private final UnaryCallSettings.Builder<CheckConsistencyRequest, CheckConsistencyResponse>
+        checkConsistencySettings;
+    private final UnaryCallSettings.Builder<SnapshotTableRequest, Operation> snapshotTableSettings;
+    private final UnaryCallSettings.Builder<GetSnapshotRequest, Snapshot> getSnapshotSettings;
+    private final PagedCallSettings.Builder<
+            ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>
+        listSnapshotsSettings;
+    private final UnaryCallSettings.Builder<DeleteSnapshotRequest, Empty> deleteSnapshotSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
         RETRYABLE_CODE_DEFINITIONS;
@@ -336,14 +473,18 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
-    private Builder() {
+    protected Builder() {
       this((ClientContext) null);
     }
 
-    private Builder(ClientContext clientContext) {
+    protected Builder(ClientContext clientContext) {
       super(clientContext);
 
       createTableSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      createTableFromSnapshotSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      createTableFromSnapshotOperationSettings = OperationCallSettings.newBuilder();
 
       listTablesSettings = PagedCallSettings.newBuilder(LIST_TABLES_PAGE_STR_FACT);
 
@@ -355,14 +496,33 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
 
       dropRowRangeSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      generateConsistencyTokenSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      checkConsistencySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      snapshotTableSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getSnapshotSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      listSnapshotsSettings = PagedCallSettings.newBuilder(LIST_SNAPSHOTS_PAGE_STR_FACT);
+
+      deleteSnapshotSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               createTableSettings,
+              createTableFromSnapshotSettings,
               listTablesSettings,
               getTableSettings,
               deleteTableSettings,
               modifyColumnFamiliesSettings,
-              dropRowRangeSettings);
+              dropRowRangeSettings,
+              generateConsistencyTokenSettings,
+              checkConsistencySettings,
+              snapshotTableSettings,
+              getSnapshotSettings,
+              listSnapshotsSettings,
+              deleteSnapshotSettings);
 
       initDefaults(this);
     }
@@ -371,7 +531,7 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
       Builder builder = new Builder((ClientContext) null);
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
       return initDefaults(builder);
     }
@@ -380,6 +540,11 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
 
       builder
           .createTableSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .createTableFromSnapshotSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
@@ -408,27 +573,97 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder
+          .generateConsistencyTokenSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .checkConsistencySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .snapshotTableSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .getSnapshotSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .listSnapshotsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder
+          .deleteSnapshotSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+      builder
+          .createTableFromSnapshotOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings
+                  .<CreateTableFromSnapshotRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .build())
+          .setResponseTransformer(
+              ProtoOperationTransformers.ResponseTransformer.create(Table.class))
+          .setMetadataTransformer(
+              ProtoOperationTransformers.MetadataTransformer.create(
+                  CreateTableFromSnapshotMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(500L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelay(Duration.ofMillis(5000L))
+                      .setInitialRpcTimeout(Duration.ZERO) // ignored
+                      .setRpcTimeoutMultiplier(1.0) // ignored
+                      .setMaxRpcTimeout(Duration.ZERO) // ignored
+                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .build()));
+
       return builder;
     }
 
-    private Builder(BigtableTableAdminSettings settings) {
+    protected Builder(BigtableTableAdminSettings settings) {
       super(settings);
 
       createTableSettings = settings.createTableSettings.toBuilder();
+      createTableFromSnapshotSettings = settings.createTableFromSnapshotSettings.toBuilder();
+      createTableFromSnapshotOperationSettings =
+          settings.createTableFromSnapshotOperationSettings.toBuilder();
       listTablesSettings = settings.listTablesSettings.toBuilder();
       getTableSettings = settings.getTableSettings.toBuilder();
       deleteTableSettings = settings.deleteTableSettings.toBuilder();
       modifyColumnFamiliesSettings = settings.modifyColumnFamiliesSettings.toBuilder();
       dropRowRangeSettings = settings.dropRowRangeSettings.toBuilder();
+      generateConsistencyTokenSettings = settings.generateConsistencyTokenSettings.toBuilder();
+      checkConsistencySettings = settings.checkConsistencySettings.toBuilder();
+      snapshotTableSettings = settings.snapshotTableSettings.toBuilder();
+      getSnapshotSettings = settings.getSnapshotSettings.toBuilder();
+      listSnapshotsSettings = settings.listSnapshotsSettings.toBuilder();
+      deleteSnapshotSettings = settings.deleteSnapshotSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               createTableSettings,
+              createTableFromSnapshotSettings,
               listTablesSettings,
               getTableSettings,
               deleteTableSettings,
               modifyColumnFamiliesSettings,
-              dropRowRangeSettings);
+              dropRowRangeSettings,
+              generateConsistencyTokenSettings,
+              checkConsistencySettings,
+              snapshotTableSettings,
+              getSnapshotSettings,
+              listSnapshotsSettings,
+              deleteSnapshotSettings);
     }
 
     /**
@@ -445,6 +680,19 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
     /** Returns the builder for the settings used for calls to createTable. */
     public UnaryCallSettings.Builder<CreateTableRequest, Table> createTableSettings() {
       return createTableSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to createTableFromSnapshot. */
+    public UnaryCallSettings.Builder<CreateTableFromSnapshotRequest, Operation>
+        createTableFromSnapshotSettings() {
+      return createTableFromSnapshotSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to createTableFromSnapshot. */
+    public OperationCallSettings.Builder<
+            CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+        createTableFromSnapshotOperationSettings() {
+      return createTableFromSnapshotOperationSettings;
     }
 
     /** Returns the builder for the settings used for calls to listTables. */
@@ -472,6 +720,41 @@ public class BigtableTableAdminSettings extends ClientSettings<BigtableTableAdmi
     /** Returns the builder for the settings used for calls to dropRowRange. */
     public UnaryCallSettings.Builder<DropRowRangeRequest, Empty> dropRowRangeSettings() {
       return dropRowRangeSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to generateConsistencyToken. */
+    public UnaryCallSettings.Builder<
+            GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+        generateConsistencyTokenSettings() {
+      return generateConsistencyTokenSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to checkConsistency. */
+    public UnaryCallSettings.Builder<CheckConsistencyRequest, CheckConsistencyResponse>
+        checkConsistencySettings() {
+      return checkConsistencySettings;
+    }
+
+    /** Returns the builder for the settings used for calls to snapshotTable. */
+    public UnaryCallSettings.Builder<SnapshotTableRequest, Operation> snapshotTableSettings() {
+      return snapshotTableSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to getSnapshot. */
+    public UnaryCallSettings.Builder<GetSnapshotRequest, Snapshot> getSnapshotSettings() {
+      return getSnapshotSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to listSnapshots. */
+    public PagedCallSettings.Builder<
+            ListSnapshotsRequest, ListSnapshotsResponse, ListSnapshotsPagedResponse>
+        listSnapshotsSettings() {
+      return listSnapshotsSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to deleteSnapshot. */
+    public UnaryCallSettings.Builder<DeleteSnapshotRequest, Empty> deleteSnapshotSettings() {
+      return deleteSnapshotSettings;
     }
 
     @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/PagedResponseWrappers.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/PagedResponseWrappers.java
@@ -23,8 +23,14 @@ import com.google.api.gax.paging.AbstractFixedSizeCollection;
 import com.google.api.gax.paging.AbstractPage;
 import com.google.api.gax.paging.AbstractPagedListResponse;
 import com.google.api.gax.rpc.PageContext;
+import com.google.bigtable.admin.v2.AppProfile;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
+import com.google.bigtable.admin.v2.Snapshot;
 import com.google.bigtable.admin.v2.Table;
 import java.util.List;
 import javax.annotation.Generated;
@@ -38,6 +44,81 @@ import javax.annotation.Generated;
 @Generated("by GAPIC")
 @BetaApi
 public class PagedResponseWrappers {
+
+  public static class ListAppProfilesPagedResponse
+      extends AbstractPagedListResponse<
+          ListAppProfilesRequest, ListAppProfilesResponse, AppProfile, ListAppProfilesPage,
+          ListAppProfilesFixedSizeCollection> {
+
+    public static ApiFuture<ListAppProfilesPagedResponse> createAsync(
+        PageContext<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile> context,
+        ApiFuture<ListAppProfilesResponse> futureResponse) {
+      ApiFuture<ListAppProfilesPage> futurePage =
+          ListAppProfilesPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListAppProfilesPage, ListAppProfilesPagedResponse>() {
+            @Override
+            public ListAppProfilesPagedResponse apply(ListAppProfilesPage input) {
+              return new ListAppProfilesPagedResponse(input);
+            }
+          });
+    }
+
+    private ListAppProfilesPagedResponse(ListAppProfilesPage page) {
+      super(page, ListAppProfilesFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class ListAppProfilesPage
+      extends AbstractPage<
+          ListAppProfilesRequest, ListAppProfilesResponse, AppProfile, ListAppProfilesPage> {
+
+    private ListAppProfilesPage(
+        PageContext<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile> context,
+        ListAppProfilesResponse response) {
+      super(context, response);
+    }
+
+    private static ListAppProfilesPage createEmptyPage() {
+      return new ListAppProfilesPage(null, null);
+    }
+
+    @Override
+    protected ListAppProfilesPage createPage(
+        PageContext<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile> context,
+        ListAppProfilesResponse response) {
+      return new ListAppProfilesPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListAppProfilesPage> createPageAsync(
+        PageContext<ListAppProfilesRequest, ListAppProfilesResponse, AppProfile> context,
+        ApiFuture<ListAppProfilesResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class ListAppProfilesFixedSizeCollection
+      extends AbstractFixedSizeCollection<
+          ListAppProfilesRequest, ListAppProfilesResponse, AppProfile, ListAppProfilesPage,
+          ListAppProfilesFixedSizeCollection> {
+
+    private ListAppProfilesFixedSizeCollection(
+        List<ListAppProfilesPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListAppProfilesFixedSizeCollection createEmptyCollection() {
+      return new ListAppProfilesFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListAppProfilesFixedSizeCollection createCollection(
+        List<ListAppProfilesPage> pages, int collectionSize) {
+      return new ListAppProfilesFixedSizeCollection(pages, collectionSize);
+    }
+  }
 
   public static class ListTablesPagedResponse
       extends AbstractPagedListResponse<
@@ -109,6 +190,80 @@ public class PagedResponseWrappers {
     protected ListTablesFixedSizeCollection createCollection(
         List<ListTablesPage> pages, int collectionSize) {
       return new ListTablesFixedSizeCollection(pages, collectionSize);
+    }
+  }
+
+  public static class ListSnapshotsPagedResponse
+      extends AbstractPagedListResponse<
+          ListSnapshotsRequest, ListSnapshotsResponse, Snapshot, ListSnapshotsPage,
+          ListSnapshotsFixedSizeCollection> {
+
+    public static ApiFuture<ListSnapshotsPagedResponse> createAsync(
+        PageContext<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot> context,
+        ApiFuture<ListSnapshotsResponse> futureResponse) {
+      ApiFuture<ListSnapshotsPage> futurePage =
+          ListSnapshotsPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListSnapshotsPage, ListSnapshotsPagedResponse>() {
+            @Override
+            public ListSnapshotsPagedResponse apply(ListSnapshotsPage input) {
+              return new ListSnapshotsPagedResponse(input);
+            }
+          });
+    }
+
+    private ListSnapshotsPagedResponse(ListSnapshotsPage page) {
+      super(page, ListSnapshotsFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class ListSnapshotsPage
+      extends AbstractPage<
+          ListSnapshotsRequest, ListSnapshotsResponse, Snapshot, ListSnapshotsPage> {
+
+    private ListSnapshotsPage(
+        PageContext<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot> context,
+        ListSnapshotsResponse response) {
+      super(context, response);
+    }
+
+    private static ListSnapshotsPage createEmptyPage() {
+      return new ListSnapshotsPage(null, null);
+    }
+
+    @Override
+    protected ListSnapshotsPage createPage(
+        PageContext<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot> context,
+        ListSnapshotsResponse response) {
+      return new ListSnapshotsPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListSnapshotsPage> createPageAsync(
+        PageContext<ListSnapshotsRequest, ListSnapshotsResponse, Snapshot> context,
+        ApiFuture<ListSnapshotsResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class ListSnapshotsFixedSizeCollection
+      extends AbstractFixedSizeCollection<
+          ListSnapshotsRequest, ListSnapshotsResponse, Snapshot, ListSnapshotsPage,
+          ListSnapshotsFixedSizeCollection> {
+
+    private ListSnapshotsFixedSizeCollection(List<ListSnapshotsPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListSnapshotsFixedSizeCollection createEmptyCollection() {
+      return new ListSnapshotsFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListSnapshotsFixedSizeCollection createCollection(
+        List<ListSnapshotsPage> pages, int collectionSize) {
+      return new ListSnapshotsFixedSizeCollection(pages, collectionSize);
     }
   }
 }

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/BigtableInstanceAdminStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/BigtableInstanceAdminStub.java
@@ -15,25 +15,40 @@
  */
 package com.google.cloud.bigtable.admin.v2.stub;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListAppProfilesPagedResponse;
+
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterMetadata;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceMetadata;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
 import com.google.bigtable.admin.v2.UpdateClusterMetadata;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
@@ -74,6 +89,10 @@ public abstract class BigtableInstanceAdminStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: updateInstanceCallable()");
   }
 
+  public UnaryCallable<PartialUpdateInstanceRequest, Operation> partialUpdateInstanceCallable() {
+    throw new UnsupportedOperationException("Not implemented: partialUpdateInstanceCallable()");
+  }
+
   public UnaryCallable<DeleteInstanceRequest, Empty> deleteInstanceCallable() {
     throw new UnsupportedOperationException("Not implemented: deleteInstanceCallable()");
   }
@@ -106,5 +125,43 @@ public abstract class BigtableInstanceAdminStub implements BackgroundResource {
 
   public UnaryCallable<DeleteClusterRequest, Empty> deleteClusterCallable() {
     throw new UnsupportedOperationException("Not implemented: deleteClusterCallable()");
+  }
+
+  public UnaryCallable<CreateAppProfileRequest, AppProfile> createAppProfileCallable() {
+    throw new UnsupportedOperationException("Not implemented: createAppProfileCallable()");
+  }
+
+  public UnaryCallable<GetAppProfileRequest, AppProfile> getAppProfileCallable() {
+    throw new UnsupportedOperationException("Not implemented: getAppProfileCallable()");
+  }
+
+  public UnaryCallable<ListAppProfilesRequest, ListAppProfilesPagedResponse>
+      listAppProfilesPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listAppProfilesPagedCallable()");
+  }
+
+  public UnaryCallable<ListAppProfilesRequest, ListAppProfilesResponse> listAppProfilesCallable() {
+    throw new UnsupportedOperationException("Not implemented: listAppProfilesCallable()");
+  }
+
+  public UnaryCallable<UpdateAppProfileRequest, Operation> updateAppProfileCallable() {
+    throw new UnsupportedOperationException("Not implemented: updateAppProfileCallable()");
+  }
+
+  public UnaryCallable<DeleteAppProfileRequest, Empty> deleteAppProfileCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteAppProfileCallable()");
+  }
+
+  public UnaryCallable<GetIamPolicyRequest, Policy> getIamPolicyCallable() {
+    throw new UnsupportedOperationException("Not implemented: getIamPolicyCallable()");
+  }
+
+  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    throw new UnsupportedOperationException("Not implemented: setIamPolicyCallable()");
+  }
+
+  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    throw new UnsupportedOperationException("Not implemented: testIamPermissionsCallable()");
   }
 }

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/BigtableTableAdminStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/BigtableTableAdminStub.java
@@ -15,19 +15,35 @@
  */
 package com.google.cloud.bigtable.admin.v2.stub;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListSnapshotsPagedResponse;
 import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListTablesPagedResponse;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.bigtable.admin.v2.Table;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
 
@@ -41,8 +57,23 @@ import javax.annotation.Generated;
 @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
 public abstract class BigtableTableAdminStub implements BackgroundResource {
 
+  public OperationsStub getOperationsStub() {
+    throw new UnsupportedOperationException("Not implemented: getOperationsStub()");
+  }
+
   public UnaryCallable<CreateTableRequest, Table> createTableCallable() {
     throw new UnsupportedOperationException("Not implemented: createTableCallable()");
+  }
+
+  public OperationCallable<CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: createTableFromSnapshotOperationCallable()");
+  }
+
+  public UnaryCallable<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotCallable() {
+    throw new UnsupportedOperationException("Not implemented: createTableFromSnapshotCallable()");
   }
 
   public UnaryCallable<ListTablesRequest, ListTablesPagedResponse> listTablesPagedCallable() {
@@ -67,5 +98,36 @@ public abstract class BigtableTableAdminStub implements BackgroundResource {
 
   public UnaryCallable<DropRowRangeRequest, Empty> dropRowRangeCallable() {
     throw new UnsupportedOperationException("Not implemented: dropRowRangeCallable()");
+  }
+
+  public UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenCallable() {
+    throw new UnsupportedOperationException("Not implemented: generateConsistencyTokenCallable()");
+  }
+
+  public UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencyCallable() {
+    throw new UnsupportedOperationException("Not implemented: checkConsistencyCallable()");
+  }
+
+  public UnaryCallable<SnapshotTableRequest, Operation> snapshotTableCallable() {
+    throw new UnsupportedOperationException("Not implemented: snapshotTableCallable()");
+  }
+
+  public UnaryCallable<GetSnapshotRequest, Snapshot> getSnapshotCallable() {
+    throw new UnsupportedOperationException("Not implemented: getSnapshotCallable()");
+  }
+
+  public UnaryCallable<ListSnapshotsRequest, ListSnapshotsPagedResponse>
+      listSnapshotsPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listSnapshotsPagedCallable()");
+  }
+
+  public UnaryCallable<ListSnapshotsRequest, ListSnapshotsResponse> listSnapshotsCallable() {
+    throw new UnsupportedOperationException("Not implemented: listSnapshotsCallable()");
+  }
+
+  public UnaryCallable<DeleteSnapshotRequest, Empty> deleteSnapshotCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteSnapshotCallable()");
   }
 }

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/GrpcBigtableInstanceAdminStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/GrpcBigtableInstanceAdminStub.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.admin.v2.stub;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListAppProfilesPagedResponse;
+
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
@@ -23,22 +25,35 @@ import com.google.api.gax.grpc.GrpcCallableFactory;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterMetadata;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceMetadata;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
 import com.google.bigtable.admin.v2.UpdateClusterMetadata;
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
 import com.google.protobuf.Empty;
@@ -91,6 +106,16 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
           .setRequestMarshaller(ProtoUtils.marshaller(Instance.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Instance.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<PartialUpdateInstanceRequest, Operation>
+      partialUpdateInstanceMethodDescriptor =
+          MethodDescriptor.<PartialUpdateInstanceRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(
+                  "google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateInstance")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(PartialUpdateInstanceRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
   private static final MethodDescriptor<DeleteInstanceRequest, Empty>
       deleteInstanceMethodDescriptor =
           MethodDescriptor.<DeleteInstanceRequest, Empty>newBuilder()
@@ -139,6 +164,77 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
           .setRequestMarshaller(ProtoUtils.marshaller(DeleteClusterRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<CreateAppProfileRequest, AppProfile>
+      createAppProfileMethodDescriptor =
+          MethodDescriptor.<CreateAppProfileRequest, AppProfile>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/CreateAppProfile")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(CreateAppProfileRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(AppProfile.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<GetAppProfileRequest, AppProfile>
+      getAppProfileMethodDescriptor =
+          MethodDescriptor.<GetAppProfileRequest, AppProfile>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/GetAppProfile")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(GetAppProfileRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(AppProfile.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<ListAppProfilesRequest, ListAppProfilesResponse>
+      listAppProfilesMethodDescriptor =
+          MethodDescriptor.<ListAppProfilesRequest, ListAppProfilesResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/ListAppProfiles")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(ListAppProfilesRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(ListAppProfilesResponse.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<UpdateAppProfileRequest, Operation>
+      updateAppProfileMethodDescriptor =
+          MethodDescriptor.<UpdateAppProfileRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateAppProfile")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(UpdateAppProfileRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<DeleteAppProfileRequest, Empty>
+      deleteAppProfileMethodDescriptor =
+          MethodDescriptor.<DeleteAppProfileRequest, Empty>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteAppProfile")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(DeleteAppProfileRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<GetIamPolicyRequest, Policy> getIamPolicyMethodDescriptor =
+      MethodDescriptor.<GetIamPolicyRequest, Policy>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/GetIamPolicy")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetIamPolicyRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Policy.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<SetIamPolicyRequest, Policy> setIamPolicyMethodDescriptor =
+      MethodDescriptor.<SetIamPolicyRequest, Policy>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.bigtable.admin.v2.BigtableInstanceAdmin/SetIamPolicy")
+          .setRequestMarshaller(ProtoUtils.marshaller(SetIamPolicyRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Policy.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsMethodDescriptor =
+          MethodDescriptor.<TestIamPermissionsRequest, TestIamPermissionsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(
+                  "google.bigtable.admin.v2.BigtableInstanceAdmin/TestIamPermissions")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(TestIamPermissionsRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(TestIamPermissionsResponse.getDefaultInstance()))
+              .build();
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -149,6 +245,8 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
   private final UnaryCallable<GetInstanceRequest, Instance> getInstanceCallable;
   private final UnaryCallable<ListInstancesRequest, ListInstancesResponse> listInstancesCallable;
   private final UnaryCallable<Instance, Instance> updateInstanceCallable;
+  private final UnaryCallable<PartialUpdateInstanceRequest, Operation>
+      partialUpdateInstanceCallable;
   private final UnaryCallable<DeleteInstanceRequest, Empty> deleteInstanceCallable;
   private final UnaryCallable<CreateClusterRequest, Operation> createClusterCallable;
   private final OperationCallable<CreateClusterRequest, Cluster, CreateClusterMetadata>
@@ -159,6 +257,18 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
   private final OperationCallable<Cluster, Cluster, UpdateClusterMetadata>
       updateClusterOperationCallable;
   private final UnaryCallable<DeleteClusterRequest, Empty> deleteClusterCallable;
+  private final UnaryCallable<CreateAppProfileRequest, AppProfile> createAppProfileCallable;
+  private final UnaryCallable<GetAppProfileRequest, AppProfile> getAppProfileCallable;
+  private final UnaryCallable<ListAppProfilesRequest, ListAppProfilesResponse>
+      listAppProfilesCallable;
+  private final UnaryCallable<ListAppProfilesRequest, ListAppProfilesPagedResponse>
+      listAppProfilesPagedCallable;
+  private final UnaryCallable<UpdateAppProfileRequest, Operation> updateAppProfileCallable;
+  private final UnaryCallable<DeleteAppProfileRequest, Empty> deleteAppProfileCallable;
+  private final UnaryCallable<GetIamPolicyRequest, Policy> getIamPolicyCallable;
+  private final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable;
+  private final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable;
 
   public static final GrpcBigtableInstanceAdminStub create(BigtableInstanceAdminSettings settings)
       throws IOException {
@@ -196,6 +306,11 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
         GrpcCallSettings.<Instance, Instance>newBuilder()
             .setMethodDescriptor(updateInstanceMethodDescriptor)
             .build();
+    GrpcCallSettings<PartialUpdateInstanceRequest, Operation>
+        partialUpdateInstanceTransportSettings =
+            GrpcCallSettings.<PartialUpdateInstanceRequest, Operation>newBuilder()
+                .setMethodDescriptor(partialUpdateInstanceMethodDescriptor)
+                .build();
     GrpcCallSettings<DeleteInstanceRequest, Empty> deleteInstanceTransportSettings =
         GrpcCallSettings.<DeleteInstanceRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteInstanceMethodDescriptor)
@@ -220,6 +335,40 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
         GrpcCallSettings.<DeleteClusterRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteClusterMethodDescriptor)
             .build();
+    GrpcCallSettings<CreateAppProfileRequest, AppProfile> createAppProfileTransportSettings =
+        GrpcCallSettings.<CreateAppProfileRequest, AppProfile>newBuilder()
+            .setMethodDescriptor(createAppProfileMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetAppProfileRequest, AppProfile> getAppProfileTransportSettings =
+        GrpcCallSettings.<GetAppProfileRequest, AppProfile>newBuilder()
+            .setMethodDescriptor(getAppProfileMethodDescriptor)
+            .build();
+    GrpcCallSettings<ListAppProfilesRequest, ListAppProfilesResponse>
+        listAppProfilesTransportSettings =
+            GrpcCallSettings.<ListAppProfilesRequest, ListAppProfilesResponse>newBuilder()
+                .setMethodDescriptor(listAppProfilesMethodDescriptor)
+                .build();
+    GrpcCallSettings<UpdateAppProfileRequest, Operation> updateAppProfileTransportSettings =
+        GrpcCallSettings.<UpdateAppProfileRequest, Operation>newBuilder()
+            .setMethodDescriptor(updateAppProfileMethodDescriptor)
+            .build();
+    GrpcCallSettings<DeleteAppProfileRequest, Empty> deleteAppProfileTransportSettings =
+        GrpcCallSettings.<DeleteAppProfileRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteAppProfileMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetIamPolicyRequest, Policy> getIamPolicyTransportSettings =
+        GrpcCallSettings.<GetIamPolicyRequest, Policy>newBuilder()
+            .setMethodDescriptor(getIamPolicyMethodDescriptor)
+            .build();
+    GrpcCallSettings<SetIamPolicyRequest, Policy> setIamPolicyTransportSettings =
+        GrpcCallSettings.<SetIamPolicyRequest, Policy>newBuilder()
+            .setMethodDescriptor(setIamPolicyMethodDescriptor)
+            .build();
+    GrpcCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsTransportSettings =
+            GrpcCallSettings.<TestIamPermissionsRequest, TestIamPermissionsResponse>newBuilder()
+                .setMethodDescriptor(testIamPermissionsMethodDescriptor)
+                .build();
 
     this.createInstanceCallable =
         GrpcCallableFactory.createUnaryCallable(
@@ -239,6 +388,11 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
     this.updateInstanceCallable =
         GrpcCallableFactory.createUnaryCallable(
             updateInstanceTransportSettings, settings.updateInstanceSettings(), clientContext);
+    this.partialUpdateInstanceCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            partialUpdateInstanceTransportSettings,
+            settings.partialUpdateInstanceSettings(),
+            clientContext);
     this.deleteInstanceCallable =
         GrpcCallableFactory.createUnaryCallable(
             deleteInstanceTransportSettings, settings.deleteInstanceSettings(), clientContext);
@@ -269,6 +423,35 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
     this.deleteClusterCallable =
         GrpcCallableFactory.createUnaryCallable(
             deleteClusterTransportSettings, settings.deleteClusterSettings(), clientContext);
+    this.createAppProfileCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            createAppProfileTransportSettings, settings.createAppProfileSettings(), clientContext);
+    this.getAppProfileCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            getAppProfileTransportSettings, settings.getAppProfileSettings(), clientContext);
+    this.listAppProfilesCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            listAppProfilesTransportSettings, settings.listAppProfilesSettings(), clientContext);
+    this.listAppProfilesPagedCallable =
+        GrpcCallableFactory.createPagedCallable(
+            listAppProfilesTransportSettings, settings.listAppProfilesSettings(), clientContext);
+    this.updateAppProfileCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            updateAppProfileTransportSettings, settings.updateAppProfileSettings(), clientContext);
+    this.deleteAppProfileCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            deleteAppProfileTransportSettings, settings.deleteAppProfileSettings(), clientContext);
+    this.getIamPolicyCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            getIamPolicyTransportSettings, settings.getIamPolicySettings(), clientContext);
+    this.setIamPolicyCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            setIamPolicyTransportSettings, settings.setIamPolicySettings(), clientContext);
+    this.testIamPermissionsCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            testIamPermissionsTransportSettings,
+            settings.testIamPermissionsSettings(),
+            clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -296,6 +479,10 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
 
   public UnaryCallable<Instance, Instance> updateInstanceCallable() {
     return updateInstanceCallable;
+  }
+
+  public UnaryCallable<PartialUpdateInstanceRequest, Operation> partialUpdateInstanceCallable() {
+    return partialUpdateInstanceCallable;
   }
 
   public UnaryCallable<DeleteInstanceRequest, Empty> deleteInstanceCallable() {
@@ -330,6 +517,44 @@ public class GrpcBigtableInstanceAdminStub extends BigtableInstanceAdminStub {
 
   public UnaryCallable<DeleteClusterRequest, Empty> deleteClusterCallable() {
     return deleteClusterCallable;
+  }
+
+  public UnaryCallable<CreateAppProfileRequest, AppProfile> createAppProfileCallable() {
+    return createAppProfileCallable;
+  }
+
+  public UnaryCallable<GetAppProfileRequest, AppProfile> getAppProfileCallable() {
+    return getAppProfileCallable;
+  }
+
+  public UnaryCallable<ListAppProfilesRequest, ListAppProfilesPagedResponse>
+      listAppProfilesPagedCallable() {
+    return listAppProfilesPagedCallable;
+  }
+
+  public UnaryCallable<ListAppProfilesRequest, ListAppProfilesResponse> listAppProfilesCallable() {
+    return listAppProfilesCallable;
+  }
+
+  public UnaryCallable<UpdateAppProfileRequest, Operation> updateAppProfileCallable() {
+    return updateAppProfileCallable;
+  }
+
+  public UnaryCallable<DeleteAppProfileRequest, Empty> deleteAppProfileCallable() {
+    return deleteAppProfileCallable;
+  }
+
+  public UnaryCallable<GetIamPolicyRequest, Policy> getIamPolicyCallable() {
+    return getIamPolicyCallable;
+  }
+
+  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    return setIamPolicyCallable;
+  }
+
+  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    return testIamPermissionsCallable;
   }
 
   @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/GrpcBigtableTableAdminStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/main/java/com/google/cloud/bigtable/admin/v2/stub/GrpcBigtableTableAdminStub.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.admin.v2.stub;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListSnapshotsPagedResponse;
 import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListTablesPagedResponse;
 
 import com.google.api.core.BetaApi;
@@ -23,16 +24,31 @@ import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.grpc.GrpcCallSettings;
 import com.google.api.gax.grpc.GrpcCallableFactory;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.GrpcOperationsStub;
 import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
@@ -57,6 +73,16 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
           .setRequestMarshaller(ProtoUtils.marshaller(CreateTableRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Table.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotMethodDescriptor =
+          MethodDescriptor.<CreateTableFromSnapshotRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(
+                  "google.bigtable.admin.v2.BigtableTableAdmin/CreateTableFromSnapshot")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(CreateTableFromSnapshotRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
   private static final MethodDescriptor<ListTablesRequest, ListTablesResponse>
       listTablesMethodDescriptor =
           MethodDescriptor.<ListTablesRequest, ListTablesResponse>newBuilder()
@@ -95,16 +121,90 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
           .setRequestMarshaller(ProtoUtils.marshaller(DropRowRangeRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<
+          GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenMethodDescriptor =
+          MethodDescriptor
+              .<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(
+                  "google.bigtable.admin.v2.BigtableTableAdmin/GenerateConsistencyToken")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(GenerateConsistencyTokenRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(GenerateConsistencyTokenResponse.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencyMethodDescriptor =
+          MethodDescriptor.<CheckConsistencyRequest, CheckConsistencyResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableTableAdmin/CheckConsistency")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(CheckConsistencyRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(CheckConsistencyResponse.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<SnapshotTableRequest, Operation>
+      snapshotTableMethodDescriptor =
+          MethodDescriptor.<SnapshotTableRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableTableAdmin/SnapshotTable")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(SnapshotTableRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<GetSnapshotRequest, Snapshot> getSnapshotMethodDescriptor =
+      MethodDescriptor.<GetSnapshotRequest, Snapshot>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.bigtable.admin.v2.BigtableTableAdmin/GetSnapshot")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetSnapshotRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Snapshot.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ListSnapshotsRequest, ListSnapshotsResponse>
+      listSnapshotsMethodDescriptor =
+          MethodDescriptor.<ListSnapshotsRequest, ListSnapshotsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableTableAdmin/ListSnapshots")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(ListSnapshotsRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(ListSnapshotsResponse.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<DeleteSnapshotRequest, Empty>
+      deleteSnapshotMethodDescriptor =
+          MethodDescriptor.<DeleteSnapshotRequest, Empty>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.admin.v2.BigtableTableAdmin/DeleteSnapshot")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(DeleteSnapshotRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+              .build();
 
   private final BackgroundResource backgroundResources;
+  private final GrpcOperationsStub operationsStub;
 
   private final UnaryCallable<CreateTableRequest, Table> createTableCallable;
+  private final UnaryCallable<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotCallable;
+  private final OperationCallable<
+          CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationCallable;
   private final UnaryCallable<ListTablesRequest, ListTablesResponse> listTablesCallable;
   private final UnaryCallable<ListTablesRequest, ListTablesPagedResponse> listTablesPagedCallable;
   private final UnaryCallable<GetTableRequest, Table> getTableCallable;
   private final UnaryCallable<DeleteTableRequest, Empty> deleteTableCallable;
   private final UnaryCallable<ModifyColumnFamiliesRequest, Table> modifyColumnFamiliesCallable;
   private final UnaryCallable<DropRowRangeRequest, Empty> dropRowRangeCallable;
+  private final UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenCallable;
+  private final UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencyCallable;
+  private final UnaryCallable<SnapshotTableRequest, Operation> snapshotTableCallable;
+  private final UnaryCallable<GetSnapshotRequest, Snapshot> getSnapshotCallable;
+  private final UnaryCallable<ListSnapshotsRequest, ListSnapshotsResponse> listSnapshotsCallable;
+  private final UnaryCallable<ListSnapshotsRequest, ListSnapshotsPagedResponse>
+      listSnapshotsPagedCallable;
+  private final UnaryCallable<DeleteSnapshotRequest, Empty> deleteSnapshotCallable;
 
   public static final GrpcBigtableTableAdminStub create(BigtableTableAdminSettings settings)
       throws IOException {
@@ -124,11 +224,17 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
    */
   protected GrpcBigtableTableAdminStub(
       BigtableTableAdminSettings settings, ClientContext clientContext) throws IOException {
+    this.operationsStub = GrpcOperationsStub.create(clientContext);
 
     GrpcCallSettings<CreateTableRequest, Table> createTableTransportSettings =
         GrpcCallSettings.<CreateTableRequest, Table>newBuilder()
             .setMethodDescriptor(createTableMethodDescriptor)
             .build();
+    GrpcCallSettings<CreateTableFromSnapshotRequest, Operation>
+        createTableFromSnapshotTransportSettings =
+            GrpcCallSettings.<CreateTableFromSnapshotRequest, Operation>newBuilder()
+                .setMethodDescriptor(createTableFromSnapshotMethodDescriptor)
+                .build();
     GrpcCallSettings<ListTablesRequest, ListTablesResponse> listTablesTransportSettings =
         GrpcCallSettings.<ListTablesRequest, ListTablesResponse>newBuilder()
             .setMethodDescriptor(listTablesMethodDescriptor)
@@ -149,10 +255,48 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
         GrpcCallSettings.<DropRowRangeRequest, Empty>newBuilder()
             .setMethodDescriptor(dropRowRangeMethodDescriptor)
             .build();
+    GrpcCallSettings<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+        generateConsistencyTokenTransportSettings =
+            GrpcCallSettings
+                .<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>newBuilder()
+                .setMethodDescriptor(generateConsistencyTokenMethodDescriptor)
+                .build();
+    GrpcCallSettings<CheckConsistencyRequest, CheckConsistencyResponse>
+        checkConsistencyTransportSettings =
+            GrpcCallSettings.<CheckConsistencyRequest, CheckConsistencyResponse>newBuilder()
+                .setMethodDescriptor(checkConsistencyMethodDescriptor)
+                .build();
+    GrpcCallSettings<SnapshotTableRequest, Operation> snapshotTableTransportSettings =
+        GrpcCallSettings.<SnapshotTableRequest, Operation>newBuilder()
+            .setMethodDescriptor(snapshotTableMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetSnapshotRequest, Snapshot> getSnapshotTransportSettings =
+        GrpcCallSettings.<GetSnapshotRequest, Snapshot>newBuilder()
+            .setMethodDescriptor(getSnapshotMethodDescriptor)
+            .build();
+    GrpcCallSettings<ListSnapshotsRequest, ListSnapshotsResponse> listSnapshotsTransportSettings =
+        GrpcCallSettings.<ListSnapshotsRequest, ListSnapshotsResponse>newBuilder()
+            .setMethodDescriptor(listSnapshotsMethodDescriptor)
+            .build();
+    GrpcCallSettings<DeleteSnapshotRequest, Empty> deleteSnapshotTransportSettings =
+        GrpcCallSettings.<DeleteSnapshotRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteSnapshotMethodDescriptor)
+            .build();
 
     this.createTableCallable =
         GrpcCallableFactory.createUnaryCallable(
             createTableTransportSettings, settings.createTableSettings(), clientContext);
+    this.createTableFromSnapshotCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            createTableFromSnapshotTransportSettings,
+            settings.createTableFromSnapshotSettings(),
+            clientContext);
+    this.createTableFromSnapshotOperationCallable =
+        GrpcCallableFactory.createOperationCallable(
+            createTableFromSnapshotTransportSettings,
+            settings.createTableFromSnapshotOperationSettings(),
+            clientContext,
+            this.operationsStub);
     this.listTablesCallable =
         GrpcCallableFactory.createUnaryCallable(
             listTablesTransportSettings, settings.listTablesSettings(), clientContext);
@@ -173,12 +317,49 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
     this.dropRowRangeCallable =
         GrpcCallableFactory.createUnaryCallable(
             dropRowRangeTransportSettings, settings.dropRowRangeSettings(), clientContext);
+    this.generateConsistencyTokenCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            generateConsistencyTokenTransportSettings,
+            settings.generateConsistencyTokenSettings(),
+            clientContext);
+    this.checkConsistencyCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            checkConsistencyTransportSettings, settings.checkConsistencySettings(), clientContext);
+    this.snapshotTableCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            snapshotTableTransportSettings, settings.snapshotTableSettings(), clientContext);
+    this.getSnapshotCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            getSnapshotTransportSettings, settings.getSnapshotSettings(), clientContext);
+    this.listSnapshotsCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            listSnapshotsTransportSettings, settings.listSnapshotsSettings(), clientContext);
+    this.listSnapshotsPagedCallable =
+        GrpcCallableFactory.createPagedCallable(
+            listSnapshotsTransportSettings, settings.listSnapshotsSettings(), clientContext);
+    this.deleteSnapshotCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            deleteSnapshotTransportSettings, settings.deleteSnapshotSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 
+  public GrpcOperationsStub getOperationsStub() {
+    return operationsStub;
+  }
+
   public UnaryCallable<CreateTableRequest, Table> createTableCallable() {
     return createTableCallable;
+  }
+
+  public OperationCallable<CreateTableFromSnapshotRequest, Table, CreateTableFromSnapshotMetadata>
+      createTableFromSnapshotOperationCallable() {
+    return createTableFromSnapshotOperationCallable;
+  }
+
+  public UnaryCallable<CreateTableFromSnapshotRequest, Operation>
+      createTableFromSnapshotCallable() {
+    return createTableFromSnapshotCallable;
   }
 
   public UnaryCallable<ListTablesRequest, ListTablesPagedResponse> listTablesPagedCallable() {
@@ -203,6 +384,37 @@ public class GrpcBigtableTableAdminStub extends BigtableTableAdminStub {
 
   public UnaryCallable<DropRowRangeRequest, Empty> dropRowRangeCallable() {
     return dropRowRangeCallable;
+  }
+
+  public UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
+      generateConsistencyTokenCallable() {
+    return generateConsistencyTokenCallable;
+  }
+
+  public UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse>
+      checkConsistencyCallable() {
+    return checkConsistencyCallable;
+  }
+
+  public UnaryCallable<SnapshotTableRequest, Operation> snapshotTableCallable() {
+    return snapshotTableCallable;
+  }
+
+  public UnaryCallable<GetSnapshotRequest, Snapshot> getSnapshotCallable() {
+    return getSnapshotCallable;
+  }
+
+  public UnaryCallable<ListSnapshotsRequest, ListSnapshotsPagedResponse>
+      listSnapshotsPagedCallable() {
+    return listSnapshotsPagedCallable;
+  }
+
+  public UnaryCallable<ListSnapshotsRequest, ListSnapshotsResponse> listSnapshotsCallable() {
+    return listSnapshotsCallable;
+  }
+
+  public UnaryCallable<DeleteSnapshotRequest, Empty> deleteSnapshotCallable() {
+    return deleteSnapshotCallable;
   }
 
   @Override

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientTest.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientTest.java
@@ -15,36 +15,57 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListAppProfilesPagedResponse;
+
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
+import com.google.bigtable.admin.v2.AppProfile;
+import com.google.bigtable.admin.v2.AppProfileName;
 import com.google.bigtable.admin.v2.Cluster;
 import com.google.bigtable.admin.v2.ClusterName;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
-import com.google.bigtable.admin.v2.Instance.Type;
 import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
 import com.google.bigtable.admin.v2.LocationName;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
 import com.google.bigtable.admin.v2.ProjectName;
-import com.google.bigtable.admin.v2.StorageType;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
+import com.google.common.collect.Lists;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +84,7 @@ public class BigtableInstanceAdminClientTest {
   private static MockBigtableTableAdmin mockBigtableTableAdmin;
   private static MockServiceHelper serviceHelper;
   private BigtableInstanceAdminClient client;
+  private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -83,9 +105,10 @@ public class BigtableInstanceAdminClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
     BigtableInstanceAdminSettings settings =
         BigtableInstanceAdminSettings.newBuilder()
-            .setTransportChannelProvider(serviceHelper.createChannelProvider())
+            .setTransportChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build();
     client = BigtableInstanceAdminClient.create(settings);
@@ -128,6 +151,10 @@ public class BigtableInstanceAdminClientTest {
     Assert.assertEquals(instanceId, actualRequest.getInstanceId());
     Assert.assertEquals(instance, actualRequest.getInstance());
     Assert.assertEquals(clusters, actualRequest.getClustersMap());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -170,6 +197,10 @@ public class BigtableInstanceAdminClientTest {
     GetInstanceRequest actualRequest = (GetInstanceRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsInstanceName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -206,6 +237,10 @@ public class BigtableInstanceAdminClientTest {
     ListInstancesRequest actualRequest = (ListInstancesRequest) actualRequests.get(0);
 
     Assert.assertEquals(parent, actualRequest.getParentAsProjectName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -226,41 +261,42 @@ public class BigtableInstanceAdminClientTest {
 
   @Test
   @SuppressWarnings("all")
-  public void updateInstanceTest() {
-    InstanceName name2 = InstanceName.of("[PROJECT]", "[INSTANCE]");
-    String displayName2 = "displayName21615000987";
-    Instance expectedResponse =
-        Instance.newBuilder().setNameWithInstanceName(name2).setDisplayName(displayName2).build();
+  public void partialUpdateInstanceTest() {
+    String name = "name3373707";
+    boolean done = true;
+    Operation expectedResponse = Operation.newBuilder().setName(name).setDone(done).build();
     mockBigtableInstanceAdmin.addResponse(expectedResponse);
 
-    InstanceName name = InstanceName.of("[PROJECT]", "[INSTANCE]");
-    String displayName = "displayName1615086568";
-    Instance.Type type = Instance.Type.TYPE_UNSPECIFIED;
+    Instance instance = Instance.newBuilder().build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
 
-    Instance actualResponse = client.updateInstance(name, displayName, type);
+    Operation actualResponse = client.partialUpdateInstance(instance, updateMask);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
     Assert.assertEquals(1, actualRequests.size());
-    Instance actualRequest = (Instance) actualRequests.get(0);
+    PartialUpdateInstanceRequest actualRequest =
+        (PartialUpdateInstanceRequest) actualRequests.get(0);
 
-    Assert.assertEquals(name, actualRequest.getNameAsInstanceName());
-    Assert.assertEquals(displayName, actualRequest.getDisplayName());
-    Assert.assertEquals(type, actualRequest.getType());
+    Assert.assertEquals(instance, actualRequest.getInstance());
+    Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
   @SuppressWarnings("all")
-  public void updateInstanceExceptionTest() throws Exception {
+  public void partialUpdateInstanceExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockBigtableInstanceAdmin.addException(exception);
 
     try {
-      InstanceName name = InstanceName.of("[PROJECT]", "[INSTANCE]");
-      String displayName = "displayName1615086568";
-      Instance.Type type = Instance.Type.TYPE_UNSPECIFIED;
+      Instance instance = Instance.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
 
-      client.updateInstance(name, displayName, type);
+      client.partialUpdateInstance(instance, updateMask);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -282,6 +318,10 @@ public class BigtableInstanceAdminClientTest {
     DeleteInstanceRequest actualRequest = (DeleteInstanceRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsInstanceName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -305,7 +345,7 @@ public class BigtableInstanceAdminClientTest {
   public void createClusterTest() throws Exception {
     ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
     LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
-    int serveNodes = -1288838783;
+    int serveNodes = 1288838783;
     Cluster expectedResponse =
         Cluster.newBuilder()
             .setNameWithClusterName(name)
@@ -334,6 +374,10 @@ public class BigtableInstanceAdminClientTest {
     Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
     Assert.assertEquals(clusterId, actualRequest.getClusterId());
     Assert.assertEquals(cluster, actualRequest.getCluster());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -361,7 +405,7 @@ public class BigtableInstanceAdminClientTest {
   public void getClusterTest() {
     ClusterName name2 = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
     LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
-    int serveNodes = -1288838783;
+    int serveNodes = 1288838783;
     Cluster expectedResponse =
         Cluster.newBuilder()
             .setNameWithClusterName(name2)
@@ -380,6 +424,10 @@ public class BigtableInstanceAdminClientTest {
     GetClusterRequest actualRequest = (GetClusterRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsClusterName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -416,6 +464,10 @@ public class BigtableInstanceAdminClientTest {
     ListClustersRequest actualRequest = (ListClustersRequest) actualRequests.get(0);
 
     Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -436,66 +488,6 @@ public class BigtableInstanceAdminClientTest {
 
   @Test
   @SuppressWarnings("all")
-  public void updateClusterTest() throws Exception {
-    ClusterName name2 = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
-    LocationName location2 = LocationName.of("[PROJECT]", "[LOCATION]");
-    int serveNodes2 = -1623486220;
-    Cluster expectedResponse =
-        Cluster.newBuilder()
-            .setNameWithClusterName(name2)
-            .setLocationWithLocationName(location2)
-            .setServeNodes(serveNodes2)
-            .build();
-    Operation resultOperation =
-        Operation.newBuilder()
-            .setName("updateClusterTest")
-            .setDone(true)
-            .setResponse(Any.pack(expectedResponse))
-            .build();
-    mockBigtableInstanceAdmin.addResponse(resultOperation);
-
-    ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
-    LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
-    int serveNodes = -1288838783;
-    StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
-
-    Cluster actualResponse =
-        client.updateClusterAsync(name, location, serveNodes, defaultStorageType).get();
-    Assert.assertEquals(expectedResponse, actualResponse);
-
-    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
-    Assert.assertEquals(1, actualRequests.size());
-    Cluster actualRequest = (Cluster) actualRequests.get(0);
-
-    Assert.assertEquals(name, actualRequest.getNameAsClusterName());
-    Assert.assertEquals(location, actualRequest.getLocationAsLocationName());
-    Assert.assertEquals(serveNodes, actualRequest.getServeNodes());
-    Assert.assertEquals(defaultStorageType, actualRequest.getDefaultStorageType());
-  }
-
-  @Test
-  @SuppressWarnings("all")
-  public void updateClusterExceptionTest() throws Exception {
-    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
-    mockBigtableInstanceAdmin.addException(exception);
-
-    try {
-      ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
-      LocationName location = LocationName.of("[PROJECT]", "[LOCATION]");
-      int serveNodes = -1288838783;
-      StorageType defaultStorageType = StorageType.STORAGE_TYPE_UNSPECIFIED;
-
-      client.updateClusterAsync(name, location, serveNodes, defaultStorageType).get();
-      Assert.fail("No exception raised");
-    } catch (ExecutionException e) {
-      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
-      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
-      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
-    }
-  }
-
-  @Test
-  @SuppressWarnings("all")
   public void deleteClusterTest() {
     Empty expectedResponse = Empty.newBuilder().build();
     mockBigtableInstanceAdmin.addResponse(expectedResponse);
@@ -509,6 +501,10 @@ public class BigtableInstanceAdminClientTest {
     DeleteClusterRequest actualRequest = (DeleteClusterRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsClusterName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -521,6 +517,349 @@ public class BigtableInstanceAdminClientTest {
       ClusterName name = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
 
       client.deleteCluster(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createAppProfileTest() {
+    String name = "name3373707";
+    String etag = "etag3123477";
+    String description = "description-1724546052";
+    AppProfile expectedResponse =
+        AppProfile.newBuilder().setName(name).setEtag(etag).setDescription(description).build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+    String appProfileId = "appProfileId1262094415";
+    AppProfile appProfile = AppProfile.newBuilder().build();
+
+    AppProfile actualResponse = client.createAppProfile(parent, appProfileId, appProfile);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateAppProfileRequest actualRequest = (CreateAppProfileRequest) actualRequests.get(0);
+
+    Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertEquals(appProfile, actualRequest.getAppProfile());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createAppProfileExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+      String appProfileId = "appProfileId1262094415";
+      AppProfile appProfile = AppProfile.newBuilder().build();
+
+      client.createAppProfile(parent, appProfileId, appProfile);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getAppProfileTest() {
+    String name2 = "name2-1052831874";
+    String etag = "etag3123477";
+    String description = "description-1724546052";
+    AppProfile expectedResponse =
+        AppProfile.newBuilder().setName(name2).setEtag(etag).setDescription(description).build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+
+    AppProfile actualResponse = client.getAppProfile(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetAppProfileRequest actualRequest = (GetAppProfileRequest) actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsAppProfileName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getAppProfileExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+
+      client.getAppProfile(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listAppProfilesTest() {
+    String nextPageToken = "";
+    AppProfile appProfilesElement = AppProfile.newBuilder().build();
+    List<AppProfile> appProfiles = Arrays.asList(appProfilesElement);
+    ListAppProfilesResponse expectedResponse =
+        ListAppProfilesResponse.newBuilder()
+            .setNextPageToken(nextPageToken)
+            .addAllAppProfiles(appProfiles)
+            .build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+
+    ListAppProfilesPagedResponse pagedListResponse = client.listAppProfiles(parent);
+
+    List<AppProfile> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getAppProfilesList().get(0), resources.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListAppProfilesRequest actualRequest = (ListAppProfilesRequest) actualRequests.get(0);
+
+    Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listAppProfilesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+
+      client.listAppProfiles(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateAppProfileTest() {
+    String name = "name3373707";
+    boolean done = true;
+    Operation expectedResponse = Operation.newBuilder().setName(name).setDone(done).build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    AppProfile appProfile = AppProfile.newBuilder().build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
+
+    Operation actualResponse = client.updateAppProfile(appProfile, updateMask);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateAppProfileRequest actualRequest = (UpdateAppProfileRequest) actualRequests.get(0);
+
+    Assert.assertEquals(appProfile, actualRequest.getAppProfile());
+    Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateAppProfileExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      AppProfile appProfile = AppProfile.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+
+      client.updateAppProfile(appProfile, updateMask);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteAppProfileTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+
+    client.deleteAppProfile(name);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteAppProfileRequest actualRequest = (DeleteAppProfileRequest) actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsAppProfileName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteAppProfileExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      AppProfileName name = AppProfileName.of("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]");
+
+      client.deleteAppProfile(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getIamPolicyTest() {
+    int version = 351608024;
+    ByteString etag = ByteString.copyFromUtf8("etag3123477");
+    Policy expectedResponse = Policy.newBuilder().setVersion(version).setEtag(etag).build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+
+    Policy actualResponse = client.getIamPolicy(formattedResource);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetIamPolicyRequest actualRequest = (GetIamPolicyRequest) actualRequests.get(0);
+
+    Assert.assertEquals(formattedResource, actualRequest.getResource());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getIamPolicyExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+
+      client.getIamPolicy(formattedResource);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void setIamPolicyTest() {
+    int version = 351608024;
+    ByteString etag = ByteString.copyFromUtf8("etag3123477");
+    Policy expectedResponse = Policy.newBuilder().setVersion(version).setEtag(etag).build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+    Policy policy = Policy.newBuilder().build();
+
+    Policy actualResponse = client.setIamPolicy(formattedResource, policy);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    SetIamPolicyRequest actualRequest = (SetIamPolicyRequest) actualRequests.get(0);
+
+    Assert.assertEquals(formattedResource, actualRequest.getResource());
+    Assert.assertEquals(policy, actualRequest.getPolicy());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void setIamPolicyExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+      Policy policy = Policy.newBuilder().build();
+
+      client.setIamPolicy(formattedResource, policy);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testIamPermissionsTest() {
+    TestIamPermissionsResponse expectedResponse = TestIamPermissionsResponse.newBuilder().build();
+    mockBigtableInstanceAdmin.addResponse(expectedResponse);
+
+    String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+    List<String> permissions = new ArrayList<>();
+
+    TestIamPermissionsResponse actualResponse =
+        client.testIamPermissions(formattedResource, permissions);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableInstanceAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestIamPermissionsRequest actualRequest = (TestIamPermissionsRequest) actualRequests.get(0);
+
+    Assert.assertEquals(formattedResource, actualRequest.getResource());
+    Assert.assertEquals(permissions, actualRequest.getPermissionsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testIamPermissionsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableInstanceAdmin.addException(exception);
+
+    try {
+      String formattedResource = InstanceName.of("[PROJECT]", "[INSTANCE]").toString();
+      List<String> permissions = new ArrayList<>();
+
+      client.testIamPermissions(formattedResource, permissions);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTest.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTest.java
@@ -15,25 +15,42 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListSnapshotsPagedResponse;
 import static com.google.cloud.bigtable.admin.v2.PagedResponseWrappers.ListTablesPagedResponse;
 
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.ClusterName;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
-import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
 import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotName;
 import com.google.bigtable.admin.v2.Table;
 import com.google.bigtable.admin.v2.TableName;
 import com.google.common.collect.Lists;
-import com.google.protobuf.ByteString;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.Status;
@@ -42,6 +59,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -55,6 +73,7 @@ public class BigtableTableAdminClientTest {
   private static MockBigtableTableAdmin mockBigtableTableAdmin;
   private static MockServiceHelper serviceHelper;
   private BigtableTableAdminClient client;
+  private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -75,9 +94,10 @@ public class BigtableTableAdminClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
     BigtableTableAdminSettings settings =
         BigtableTableAdminSettings.newBuilder()
-            .setTransportChannelProvider(serviceHelper.createChannelProvider())
+            .setTransportChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build();
     client = BigtableTableAdminClient.create(settings);
@@ -109,6 +129,10 @@ public class BigtableTableAdminClientTest {
     Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
     Assert.assertEquals(tableId, actualRequest.getTableId());
     Assert.assertEquals(table, actualRequest.getTable());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -126,6 +150,61 @@ public class BigtableTableAdminClientTest {
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createTableFromSnapshotTest() throws Exception {
+    TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    Table expectedResponse = Table.newBuilder().setNameWithTableName(name).build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("createTableFromSnapshotTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockBigtableTableAdmin.addResponse(resultOperation);
+
+    InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+    String tableId = "tableId-895419604";
+    String sourceSnapshot = "sourceSnapshot-947679896";
+
+    Table actualResponse =
+        client.createTableFromSnapshotAsync(parent, tableId, sourceSnapshot).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateTableFromSnapshotRequest actualRequest =
+        (CreateTableFromSnapshotRequest) actualRequests.get(0);
+
+    Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
+    Assert.assertEquals(tableId, actualRequest.getTableId());
+    Assert.assertEquals(sourceSnapshot, actualRequest.getSourceSnapshot());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createTableFromSnapshotExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableTableAdmin.addException(exception);
+
+    try {
+      InstanceName parent = InstanceName.of("[PROJECT]", "[INSTANCE]");
+      String tableId = "tableId-895419604";
+      String sourceSnapshot = "sourceSnapshot-947679896";
+
+      client.createTableFromSnapshotAsync(parent, tableId, sourceSnapshot).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
   }
 
@@ -155,6 +234,10 @@ public class BigtableTableAdminClientTest {
     ListTablesRequest actualRequest = (ListTablesRequest) actualRequests.get(0);
 
     Assert.assertEquals(parent, actualRequest.getParentAsInstanceName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -190,6 +273,10 @@ public class BigtableTableAdminClientTest {
     GetTableRequest actualRequest = (GetTableRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsTableName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -223,6 +310,10 @@ public class BigtableTableAdminClientTest {
     DeleteTableRequest actualRequest = (DeleteTableRequest) actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsTableName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -260,6 +351,10 @@ public class BigtableTableAdminClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsTableName());
     Assert.assertEquals(modifications, actualRequest.getModificationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -281,34 +376,213 @@ public class BigtableTableAdminClientTest {
 
   @Test
   @SuppressWarnings("all")
-  public void dropRowRangeTest() {
-    Empty expectedResponse = Empty.newBuilder().build();
+  public void generateConsistencyTokenTest() {
+    String consistencyToken = "consistencyToken-1090516718";
+    GenerateConsistencyTokenResponse expectedResponse =
+        GenerateConsistencyTokenResponse.newBuilder().setConsistencyToken(consistencyToken).build();
     mockBigtableTableAdmin.addResponse(expectedResponse);
 
-    String formattedName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
-    ByteString rowKeyPrefix = ByteString.copyFromUtf8("-9");
+    TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
 
-    client.dropRowRange(formattedName, rowKeyPrefix);
+    GenerateConsistencyTokenResponse actualResponse = client.generateConsistencyToken(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
 
     List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
     Assert.assertEquals(1, actualRequests.size());
-    DropRowRangeRequest actualRequest = (DropRowRangeRequest) actualRequests.get(0);
+    GenerateConsistencyTokenRequest actualRequest =
+        (GenerateConsistencyTokenRequest) actualRequests.get(0);
 
-    Assert.assertEquals(formattedName, actualRequest.getName());
-    Assert.assertEquals(rowKeyPrefix, actualRequest.getRowKeyPrefix());
+    Assert.assertEquals(name, actualRequest.getNameAsTableName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
   @SuppressWarnings("all")
-  public void dropRowRangeExceptionTest() throws Exception {
+  public void generateConsistencyTokenExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockBigtableTableAdmin.addException(exception);
 
     try {
-      String formattedName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
-      ByteString rowKeyPrefix = ByteString.copyFromUtf8("-9");
+      TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
 
-      client.dropRowRange(formattedName, rowKeyPrefix);
+      client.generateConsistencyToken(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void checkConsistencyTest() {
+    boolean consistent = true;
+    CheckConsistencyResponse expectedResponse =
+        CheckConsistencyResponse.newBuilder().setConsistent(consistent).build();
+    mockBigtableTableAdmin.addResponse(expectedResponse);
+
+    TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    String consistencyToken = "consistencyToken-1090516718";
+
+    CheckConsistencyResponse actualResponse = client.checkConsistency(name, consistencyToken);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CheckConsistencyRequest actualRequest = (CheckConsistencyRequest) actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsTableName());
+    Assert.assertEquals(consistencyToken, actualRequest.getConsistencyToken());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void checkConsistencyExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableTableAdmin.addException(exception);
+
+    try {
+      TableName name = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      String consistencyToken = "consistencyToken-1090516718";
+
+      client.checkConsistency(name, consistencyToken);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getSnapshotTest() {
+    String name2 = "name2-1052831874";
+    long dataSizeBytes = 2110122398L;
+    String description = "description-1724546052";
+    Snapshot expectedResponse =
+        Snapshot.newBuilder()
+            .setName(name2)
+            .setDataSizeBytes(dataSizeBytes)
+            .setDescription(description)
+            .build();
+    mockBigtableTableAdmin.addResponse(expectedResponse);
+
+    SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+
+    Snapshot actualResponse = client.getSnapshot(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetSnapshotRequest actualRequest = (GetSnapshotRequest) actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsSnapshotName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getSnapshotExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableTableAdmin.addException(exception);
+
+    try {
+      SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+
+      client.getSnapshot(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listSnapshotsTest() {
+    String nextPageToken = "";
+    Snapshot snapshotsElement = Snapshot.newBuilder().build();
+    List<Snapshot> snapshots = Arrays.asList(snapshotsElement);
+    ListSnapshotsResponse expectedResponse =
+        ListSnapshotsResponse.newBuilder()
+            .setNextPageToken(nextPageToken)
+            .addAllSnapshots(snapshots)
+            .build();
+    mockBigtableTableAdmin.addResponse(expectedResponse);
+
+    ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+
+    ListSnapshotsPagedResponse pagedListResponse = client.listSnapshots(parent);
+
+    List<Snapshot> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getSnapshotsList().get(0), resources.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListSnapshotsRequest actualRequest = (ListSnapshotsRequest) actualRequests.get(0);
+
+    Assert.assertEquals(parent, actualRequest.getParentAsClusterName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listSnapshotsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableTableAdmin.addException(exception);
+
+    try {
+      ClusterName parent = ClusterName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]");
+
+      client.listSnapshots(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteSnapshotTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockBigtableTableAdmin.addResponse(expectedResponse);
+
+    SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+
+    client.deleteSnapshot(name);
+
+    List<GeneratedMessageV3> actualRequests = mockBigtableTableAdmin.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteSnapshotRequest actualRequest = (DeleteSnapshotRequest) actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsSnapshotName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteSnapshotExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockBigtableTableAdmin.addException(exception);
+
+    try {
+      SnapshotName name = SnapshotName.of("[PROJECT]", "[INSTANCE]", "[CLUSTER]", "[SNAPSHOT]");
+
+      client.deleteSnapshot(name);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/MockBigtableInstanceAdminImpl.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/MockBigtableInstanceAdminImpl.java
@@ -16,19 +16,32 @@
 package com.google.cloud.bigtable.admin.v2;
 
 import com.google.api.core.BetaApi;
+import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.BigtableInstanceAdminGrpc.BigtableInstanceAdminImplBase;
 import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.CreateAppProfileRequest;
 import com.google.bigtable.admin.v2.CreateClusterRequest;
 import com.google.bigtable.admin.v2.CreateInstanceRequest;
+import com.google.bigtable.admin.v2.DeleteAppProfileRequest;
 import com.google.bigtable.admin.v2.DeleteClusterRequest;
 import com.google.bigtable.admin.v2.DeleteInstanceRequest;
+import com.google.bigtable.admin.v2.GetAppProfileRequest;
 import com.google.bigtable.admin.v2.GetClusterRequest;
 import com.google.bigtable.admin.v2.GetInstanceRequest;
 import com.google.bigtable.admin.v2.Instance;
+import com.google.bigtable.admin.v2.ListAppProfilesRequest;
+import com.google.bigtable.admin.v2.ListAppProfilesResponse;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.bigtable.admin.v2.ListInstancesRequest;
 import com.google.bigtable.admin.v2.ListInstancesResponse;
+import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
+import com.google.bigtable.admin.v2.UpdateAppProfileRequest;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
@@ -129,6 +142,21 @@ public class MockBigtableInstanceAdminImpl extends BigtableInstanceAdminImplBase
   }
 
   @Override
+  public void partialUpdateInstance(
+      PartialUpdateInstanceRequest request, StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
   public void deleteInstance(
       DeleteInstanceRequest request, StreamObserver<Empty> responseObserver) {
     Object response = responses.remove();
@@ -207,6 +235,125 @@ public class MockBigtableInstanceAdminImpl extends BigtableInstanceAdminImplBase
     if (response instanceof Empty) {
       requests.add(request);
       responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createAppProfile(
+      CreateAppProfileRequest request, StreamObserver<AppProfile> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof AppProfile) {
+      requests.add(request);
+      responseObserver.onNext((AppProfile) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getAppProfile(
+      GetAppProfileRequest request, StreamObserver<AppProfile> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof AppProfile) {
+      requests.add(request);
+      responseObserver.onNext((AppProfile) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void listAppProfiles(
+      ListAppProfilesRequest request, StreamObserver<ListAppProfilesResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ListAppProfilesResponse) {
+      requests.add(request);
+      responseObserver.onNext((ListAppProfilesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void updateAppProfile(
+      UpdateAppProfileRequest request, StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void deleteAppProfile(
+      DeleteAppProfileRequest request, StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getIamPolicy(GetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Policy) {
+      requests.add(request);
+      responseObserver.onNext((Policy) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void setIamPolicy(SetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Policy) {
+      requests.add(request);
+      responseObserver.onNext((Policy) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void testIamPermissions(
+      TestIamPermissionsRequest request,
+      StreamObserver<TestIamPermissionsResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof TestIamPermissionsResponse) {
+      requests.add(request);
+      responseObserver.onNext((TestIamPermissionsResponse) response);
       responseObserver.onCompleted();
     } else if (response instanceof Exception) {
       responseObserver.onError((Exception) response);

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/MockBigtableTableAdminImpl.java
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/src/test/java/com/google/cloud/bigtable/admin/v2/MockBigtableTableAdminImpl.java
@@ -17,14 +17,26 @@ package com.google.cloud.bigtable.admin.v2;
 
 import com.google.api.core.BetaApi;
 import com.google.bigtable.admin.v2.BigtableTableAdminGrpc.BigtableTableAdminImplBase;
+import com.google.bigtable.admin.v2.CheckConsistencyRequest;
+import com.google.bigtable.admin.v2.CheckConsistencyResponse;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
+import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
 import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.bigtable.admin.v2.Table;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.stub.StreamObserver;
@@ -71,6 +83,21 @@ public class MockBigtableTableAdminImpl extends BigtableTableAdminImplBase {
     if (response instanceof Table) {
       requests.add(request);
       responseObserver.onNext((Table) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createTableFromSnapshot(
+      CreateTableFromSnapshotRequest request, StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
       responseObserver.onCompleted();
     } else if (response instanceof Exception) {
       responseObserver.onError((Exception) response);
@@ -139,6 +166,96 @@ public class MockBigtableTableAdminImpl extends BigtableTableAdminImplBase {
 
   @Override
   public void dropRowRange(DropRowRangeRequest request, StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void generateConsistencyToken(
+      GenerateConsistencyTokenRequest request,
+      StreamObserver<GenerateConsistencyTokenResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof GenerateConsistencyTokenResponse) {
+      requests.add(request);
+      responseObserver.onNext((GenerateConsistencyTokenResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void checkConsistency(
+      CheckConsistencyRequest request, StreamObserver<CheckConsistencyResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof CheckConsistencyResponse) {
+      requests.add(request);
+      responseObserver.onNext((CheckConsistencyResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void snapshotTable(
+      SnapshotTableRequest request, StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getSnapshot(GetSnapshotRequest request, StreamObserver<Snapshot> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Snapshot) {
+      requests.add(request);
+      responseObserver.onNext((Snapshot) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void listSnapshots(
+      ListSnapshotsRequest request, StreamObserver<ListSnapshotsResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ListSnapshotsResponse) {
+      requests.add(request);
+      responseObserver.onNext((ListSnapshotsResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void deleteSnapshot(
+      DeleteSnapshotRequest request, StreamObserver<Empty> responseObserver) {
     Object response = responses.remove();
     if (response instanceof Empty) {
       requests.add(request);

--- a/generated/java/gapic-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-bigtable-v2/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile project(":proto-google-cloud-bigtable-v2")
   compile libraries.gax, libraries.gaxGrpc
   testCompile project(":grpc-google-cloud-bigtable-v2")
-  testCompile project(":grpc-google-iam-v1")
 }
 
 sourceSets {

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
@@ -35,7 +35,7 @@ import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.bigtable.v2.TableName;
-import com.google.cloud.bigtable.v2.stub.BigtableStub;
+import com.google.cloud.bigtable.data.v2.stub.BigtableStub;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.List;
@@ -51,17 +51,18 @@ import javax.annotation.Generated;
  *
  * <pre>
  * <code>
- * try (BigtableClient bigtableClient = BigtableClient.create()) {
+ * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
  *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
  *   ByteString rowKey = ByteString.copyFromUtf8("");
  *   List&lt;Mutation&gt; mutations = new ArrayList&lt;&gt;();
- *   MutateRowResponse response = bigtableClient.mutateRow(tableName, rowKey, mutations);
+ *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
  * }
  * </code>
  * </pre>
  *
- * <p>Note: close() needs to be called on the bigtableClient object to clean up resources such as
- * threads. In the example above, try-with-resources is used, which automatically calls close().
+ * <p>Note: close() needs to be called on the baseBigtableDataClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
  *
  * <p>The surface of this class includes several types of Java methods for each of the API's
  * methods:
@@ -83,19 +84,19 @@ import javax.annotation.Generated;
  * these names, this class includes a format method for each type of name, and additionally a parse
  * method to extract the individual identifiers contained within names that are returned.
  *
- * <p>This class can be customized by passing in a custom instance of BigtableSettings to create().
- * For example:
+ * <p>This class can be customized by passing in a custom instance of BaseBigtableDataSettings to
+ * create(). For example:
  *
  * <p>To customize credentials:
  *
  * <pre>
  * <code>
- * BigtableSettings bigtableSettings =
- *     BigtableSettings.newBuilder()
+ * BaseBigtableDataSettings baseBigtableDataSettings =
+ *     BaseBigtableDataSettings.newBuilder()
  *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
  *         .build();
- * BigtableClient bigtableClient =
- *     BigtableClient.create(bigtableSettings);
+ * BaseBigtableDataClient baseBigtableDataClient =
+ *     BaseBigtableDataClient.create(baseBigtableDataSettings);
  * </code>
  * </pre>
  *
@@ -103,57 +104,59 @@ import javax.annotation.Generated;
  *
  * <pre>
  * <code>
- * BigtableSettings bigtableSettings =
- *     BigtableSettings.newBuilder().setEndpoint(myEndpoint).build();
- * BigtableClient bigtableClient =
- *     BigtableClient.create(bigtableSettings);
+ * BaseBigtableDataSettings baseBigtableDataSettings =
+ *     BaseBigtableDataSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * BaseBigtableDataClient baseBigtableDataClient =
+ *     BaseBigtableDataClient.create(baseBigtableDataSettings);
  * </code>
  * </pre>
  */
 @Generated("by GAPIC v0.0.5")
 @BetaApi
-public class BigtableClient implements BackgroundResource {
-  private final BigtableSettings settings;
+public class BaseBigtableDataClient implements BackgroundResource {
+  private final BaseBigtableDataSettings settings;
   private final BigtableStub stub;
 
-  /** Constructs an instance of BigtableClient with default settings. */
-  public static final BigtableClient create() throws IOException {
-    return create(BigtableSettings.newBuilder().build());
+  /** Constructs an instance of BaseBigtableDataClient with default settings. */
+  public static final BaseBigtableDataClient create() throws IOException {
+    return create(BaseBigtableDataSettings.newBuilder().build());
   }
 
   /**
-   * Constructs an instance of BigtableClient, using the given settings. The channels are created
-   * based on the settings passed in, or defaults for any settings that are not set.
+   * Constructs an instance of BaseBigtableDataClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
    */
-  public static final BigtableClient create(BigtableSettings settings) throws IOException {
-    return new BigtableClient(settings);
+  public static final BaseBigtableDataClient create(BaseBigtableDataSettings settings)
+      throws IOException {
+    return new BaseBigtableDataClient(settings);
   }
 
   /**
-   * Constructs an instance of BigtableClient, using the given stub for making calls. This is for
-   * advanced usage - prefer to use BigtableSettings}.
+   * Constructs an instance of BaseBigtableDataClient, using the given stub for making calls. This
+   * is for advanced usage - prefer to use BaseBigtableDataSettings}.
    */
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
-  public static final BigtableClient create(BigtableStub stub) {
-    return new BigtableClient(stub);
+  public static final BaseBigtableDataClient create(BigtableStub stub) {
+    return new BaseBigtableDataClient(stub);
   }
 
   /**
-   * Constructs an instance of BigtableClient, using the given settings. This is protected so that
-   * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   * Constructs an instance of BaseBigtableDataClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
    */
-  protected BigtableClient(BigtableSettings settings) throws IOException {
+  protected BaseBigtableDataClient(BaseBigtableDataSettings settings) throws IOException {
     this.settings = settings;
     this.stub = settings.createStub();
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
-  protected BigtableClient(BigtableStub stub) {
+  protected BaseBigtableDataClient(BigtableStub stub) {
     this.settings = null;
     this.stub = stub;
   }
 
-  public final BigtableSettings getSettings() {
+  public final BaseBigtableDataSettings getSettings() {
     return settings;
   }
 
@@ -172,7 +175,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   ApiStreamObserver&lt;ReadRowsResponse&gt; responseObserver =
    *       new ApiStreamObserver&lt;ReadRowsResponse&gt;() {
    *         {@literal @}Override
@@ -196,7 +199,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setTableNameWithTableName(tableName)
    *     .build();
    *
-   *   bigtableClient.readRowsCallable().serverStreamingCall(request, responseObserver));
+   *   baseBigtableDataClient.readRowsCallable().serverStreamingCall(request, responseObserver));
    * }
    * </code></pre>
    */
@@ -213,7 +216,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   ApiStreamObserver&lt;SampleRowKeysResponse&gt; responseObserver =
    *       new ApiStreamObserver&lt;SampleRowKeysResponse&gt;() {
    *         {@literal @}Override
@@ -237,7 +240,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setTableNameWithTableName(tableName)
    *     .build();
    *
-   *   bigtableClient.sampleRowKeysCallable().serverStreamingCall(request, responseObserver));
+   *   baseBigtableDataClient.sampleRowKeysCallable().serverStreamingCall(request, responseObserver));
    * }
    * </code></pre>
    */
@@ -254,11 +257,11 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;Mutation&gt; mutations = new ArrayList&lt;&gt;();
-   *   MutateRowResponse response = bigtableClient.mutateRow(tableName, rowKey, mutations);
+   *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
    * }
    * </code></pre>
    *
@@ -290,7 +293,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;Mutation&gt; mutations = new ArrayList&lt;&gt;();
@@ -299,7 +302,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setRowKey(rowKey)
    *     .addAllMutations(mutations)
    *     .build();
-   *   MutateRowResponse response = bigtableClient.mutateRow(request);
+   *   MutateRowResponse response = baseBigtableDataClient.mutateRow(request);
    * }
    * </code></pre>
    *
@@ -318,7 +321,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;Mutation&gt; mutations = new ArrayList&lt;&gt;();
@@ -327,7 +330,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setRowKey(rowKey)
    *     .addAllMutations(mutations)
    *     .build();
-   *   ApiFuture&lt;MutateRowResponse&gt; future = bigtableClient.mutateRowCallable().futureCall(request);
+   *   ApiFuture&lt;MutateRowResponse&gt; future = baseBigtableDataClient.mutateRowCallable().futureCall(request);
    *   // Do something
    *   MutateRowResponse response = future.get();
    * }
@@ -345,7 +348,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   ApiStreamObserver&lt;MutateRowsResponse&gt; responseObserver =
    *       new ApiStreamObserver&lt;MutateRowsResponse&gt;() {
    *         {@literal @}Override
@@ -371,7 +374,7 @@ public class BigtableClient implements BackgroundResource {
    *     .addAllEntries(entries)
    *     .build();
    *
-   *   bigtableClient.mutateRowsCallable().serverStreamingCall(request, responseObserver));
+   *   baseBigtableDataClient.mutateRowsCallable().serverStreamingCall(request, responseObserver));
    * }
    * </code></pre>
    */
@@ -386,13 +389,13 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   RowFilter predicateFilter = RowFilter.newBuilder().build();
    *   List&lt;Mutation&gt; trueMutations = new ArrayList&lt;&gt;();
    *   List&lt;Mutation&gt; falseMutations = new ArrayList&lt;&gt;();
-   *   CheckAndMutateRowResponse response = bigtableClient.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+   *   CheckAndMutateRowResponse response = baseBigtableDataClient.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
    * }
    * </code></pre>
    *
@@ -438,14 +441,14 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   CheckAndMutateRowRequest request = CheckAndMutateRowRequest.newBuilder()
    *     .setTableNameWithTableName(tableName)
    *     .setRowKey(rowKey)
    *     .build();
-   *   CheckAndMutateRowResponse response = bigtableClient.checkAndMutateRow(request);
+   *   CheckAndMutateRowResponse response = baseBigtableDataClient.checkAndMutateRow(request);
    * }
    * </code></pre>
    *
@@ -463,14 +466,14 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   CheckAndMutateRowRequest request = CheckAndMutateRowRequest.newBuilder()
    *     .setTableNameWithTableName(tableName)
    *     .setRowKey(rowKey)
    *     .build();
-   *   ApiFuture&lt;CheckAndMutateRowResponse&gt; future = bigtableClient.checkAndMutateRowCallable().futureCall(request);
+   *   ApiFuture&lt;CheckAndMutateRowResponse&gt; future = baseBigtableDataClient.checkAndMutateRowCallable().futureCall(request);
    *   // Do something
    *   CheckAndMutateRowResponse response = future.get();
    * }
@@ -491,11 +494,11 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;ReadModifyWriteRule&gt; rules = new ArrayList&lt;&gt;();
-   *   ReadModifyWriteRowResponse response = bigtableClient.readModifyWriteRow(tableName, rowKey, rules);
+   *   ReadModifyWriteRowResponse response = baseBigtableDataClient.readModifyWriteRow(tableName, rowKey, rules);
    * }
    * </code></pre>
    *
@@ -530,7 +533,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;ReadModifyWriteRule&gt; rules = new ArrayList&lt;&gt;();
@@ -539,7 +542,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setRowKey(rowKey)
    *     .addAllRules(rules)
    *     .build();
-   *   ReadModifyWriteRowResponse response = bigtableClient.readModifyWriteRow(request);
+   *   ReadModifyWriteRowResponse response = baseBigtableDataClient.readModifyWriteRow(request);
    * }
    * </code></pre>
    *
@@ -560,7 +563,7 @@ public class BigtableClient implements BackgroundResource {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (BigtableClient bigtableClient = BigtableClient.create()) {
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
    *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
    *   ByteString rowKey = ByteString.copyFromUtf8("");
    *   List&lt;ReadModifyWriteRule&gt; rules = new ArrayList&lt;&gt;();
@@ -569,7 +572,7 @@ public class BigtableClient implements BackgroundResource {
    *     .setRowKey(rowKey)
    *     .addAllRules(rules)
    *     .build();
-   *   ApiFuture&lt;ReadModifyWriteRowResponse&gt; future = bigtableClient.readModifyWriteRowCallable().futureCall(request);
+   *   ApiFuture&lt;ReadModifyWriteRowResponse&gt; future = baseBigtableDataClient.readModifyWriteRowCallable().futureCall(request);
    *   // Do something
    *   ReadModifyWriteRowResponse response = future.get();
    * }

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
-import com.google.api.gax.grpc.GrpcExtraHeaderData;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -43,8 +43,8 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.v2.SampleRowKeysResponse;
-import com.google.cloud.bigtable.v2.stub.BigtableStub;
-import com.google.cloud.bigtable.v2.stub.GrpcBigtableStub;
+import com.google.cloud.bigtable.data.v2.stub.BigtableStub;
+import com.google.cloud.bigtable.data.v2.stub.GrpcBigtableStub;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -56,7 +56,7 @@ import org.threeten.bp.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Settings class to configure an instance of {@link BigtableClient}.
+ * Settings class to configure an instance of {@link BaseBigtableDataClient}.
  *
  * <p>The default instance has everything set to sensible defaults:
  *
@@ -72,17 +72,17 @@ import org.threeten.bp.Duration;
  *
  * <pre>
  * <code>
- * BigtableSettings.Builder bigtableSettingsBuilder =
- *     BigtableSettings.newBuilder();
- * bigtableSettingsBuilder.mutateRowSettings().getRetrySettingsBuilder()
+ * BaseBigtableDataSettings.Builder baseBigtableDataSettingsBuilder =
+ *     BaseBigtableDataSettings.newBuilder();
+ * baseBigtableDataSettingsBuilder.mutateRowSettings().getRetrySettingsBuilder()
  *     .setTotalTimeout(Duration.ofSeconds(30));
- * BigtableSettings bigtableSettings = bigtableSettingsBuilder.build();
+ * BaseBigtableDataSettings baseBigtableDataSettings = baseBigtableDataSettingsBuilder.build();
  * </code>
  * </pre>
  */
 @Generated("by GAPIC v0.0.5")
 @BetaApi
-public class BigtableSettings extends ClientSettings<BigtableSettings> {
+public class BaseBigtableDataSettings extends ClientSettings<BaseBigtableDataSettings> {
   /** The default scopes of the service. */
   private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
       ImmutableList.<String>builder()
@@ -93,14 +93,6 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
           .add("https://www.googleapis.com/auth/cloud-platform")
           .add("https://www.googleapis.com/auth/cloud-platform.read-only")
           .build();
-
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE = "/com/google/cloud/bigtable/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
 
   private final StreamingCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsSettings;
   private final StreamingCallSettings<SampleRowKeysRequest, SampleRowKeysResponse>
@@ -189,19 +181,10 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData());
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion =
-          PropertiesProvider.loadProperty(
-              BigtableSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+        .setGeneratedLibToken(
+            "gapic", GaxProperties.getLibraryVersion(BaseBigtableDataSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /** Returns a new builder for this class. */
@@ -219,7 +202,7 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
     return new Builder(this);
   }
 
-  private BigtableSettings(Builder settingsBuilder) throws IOException {
+  protected BaseBigtableDataSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
 
     readRowsSettings = settingsBuilder.readRowsSettings().build();
@@ -230,8 +213,8 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
     readModifyWriteRowSettings = settingsBuilder.readModifyWriteRowSettings().build();
   }
 
-  /** Builder for BigtableSettings. */
-  public static class Builder extends ClientSettings.Builder<BigtableSettings, Builder> {
+  /** Builder for BaseBigtableDataSettings. */
+  public static class Builder extends ClientSettings.Builder<BaseBigtableDataSettings, Builder> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final StreamingCallSettings.Builder<ReadRowsRequest, ReadRowsResponse> readRowsSettings;
@@ -279,11 +262,11 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
-    private Builder() {
+    protected Builder() {
       this((ClientContext) null);
     }
 
-    private Builder(ClientContext clientContext) {
+    protected Builder(ClientContext clientContext) {
       super(clientContext);
 
       readRowsSettings = StreamingCallSettings.newBuilder();
@@ -309,7 +292,7 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
       Builder builder = new Builder((ClientContext) null);
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
       return initDefaults(builder);
     }
@@ -334,7 +317,7 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
       return builder;
     }
 
-    private Builder(BigtableSettings settings) {
+    protected Builder(BaseBigtableDataSettings settings) {
       super(settings);
 
       readRowsSettings = settings.readRowsSettings.toBuilder();
@@ -395,8 +378,8 @@ public class BigtableSettings extends ClientSettings<BigtableSettings> {
     }
 
     @Override
-    public BigtableSettings build() throws IOException {
-      return new BigtableSettings(this);
+    public BaseBigtableDataSettings build() throws IOException {
+      return new BaseBigtableDataSettings(this);
     }
   }
 }

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/package-info.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/package-info.java
@@ -19,21 +19,21 @@
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *
- * <p>============== BigtableClient ==============
+ * <p>====================== BaseBigtableDataClient ======================
  *
  * <p>Service Description: Service for reading from and writing to existing Bigtable tables.
  *
- * <p>Sample for BigtableClient:
+ * <p>Sample for BaseBigtableDataClient:
  *
  * <pre>
  * <code>
- * try (BigtableClient bigtableClient = BigtableClient.create()) {
+ * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
  *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
  *   ByteString rowKey = ByteString.copyFromUtf8("");
  *   List&lt;Mutation&gt; mutations = new ArrayList&lt;&gt;();
- *   MutateRowResponse response = bigtableClient.mutateRow(tableName, rowKey, mutations);
+ *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
  * }
  * </code>
  * </pre>
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2.stub;
+package com.google.cloud.bigtable.data.v2.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/main/java/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2.stub;
+package com.google.cloud.bigtable.data.v2.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
@@ -35,7 +35,7 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.v2.SampleRowKeysResponse;
-import com.google.cloud.bigtable.v2.BigtableSettings;
+import com.google.cloud.bigtable.data.v2.BaseBigtableDataSettings;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -119,19 +119,20 @@ public class GrpcBigtableStub extends BigtableStub {
   private final UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
       readModifyWriteRowCallable;
 
-  public static final GrpcBigtableStub create(BigtableSettings settings) throws IOException {
+  public static final GrpcBigtableStub create(BaseBigtableDataSettings settings)
+      throws IOException {
     return new GrpcBigtableStub(settings, ClientContext.create(settings));
   }
 
   public static final GrpcBigtableStub create(ClientContext clientContext) throws IOException {
-    return new GrpcBigtableStub(BigtableSettings.newBuilder().build(), clientContext);
+    return new GrpcBigtableStub(BaseBigtableDataSettings.newBuilder().build(), clientContext);
   }
 
   /**
    * Constructs an instance of GrpcBigtableStub, using the given settings. This is protected so that
    * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
    */
-  protected GrpcBigtableStub(BigtableSettings settings, ClientContext clientContext)
+  protected GrpcBigtableStub(BaseBigtableDataSettings settings, ClientContext clientContext)
       throws IOException {
 
     GrpcCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsTransportSettings =

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;
 
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.grpc.testing.MockStreamObserver;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
@@ -55,10 +58,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
-public class BigtableClientTest {
+public class BaseBigtableDataClientTest {
   private static MockBigtable mockBigtable;
   private static MockServiceHelper serviceHelper;
-  private BigtableClient client;
+  private BaseBigtableDataClient client;
+  private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -76,12 +80,13 @@ public class BigtableClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
-    BigtableSettings settings =
-        BigtableSettings.newBuilder()
-            .setTransportChannelProvider(serviceHelper.createChannelProvider())
+    channelProvider = serviceHelper.createChannelProvider();
+    BaseBigtableDataSettings settings =
+        BaseBigtableDataSettings.newBuilder()
+            .setTransportChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build();
-    client = BigtableClient.create(settings);
+    client = BaseBigtableDataClient.create(settings);
   }
 
   @After
@@ -202,6 +207,10 @@ public class BigtableClientTest {
     Assert.assertEquals(tableName, actualRequest.getTableNameAsTableName());
     Assert.assertEquals(rowKey, actualRequest.getRowKey());
     Assert.assertEquals(mutations, actualRequest.getMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -302,6 +311,10 @@ public class BigtableClientTest {
     Assert.assertEquals(predicateFilter, actualRequest.getPredicateFilter());
     Assert.assertEquals(trueMutations, actualRequest.getTrueMutationsList());
     Assert.assertEquals(falseMutations, actualRequest.getFalseMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -344,6 +357,10 @@ public class BigtableClientTest {
     Assert.assertEquals(tableName, actualRequest.getTableNameAsTableName());
     Assert.assertEquals(rowKey, actualRequest.getRowKey());
     Assert.assertEquals(rules, actualRequest.getRulesList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/MockBigtable.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/MockBigtable.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.testing.MockGrpcService;

--- a/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
+++ b/generated/java/gapic-google-cloud-bigtable-v2/src/test/java/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.v2;
+package com.google.cloud.bigtable.data.v2;
 
 import com.google.api.core.BetaApi;
 import com.google.bigtable.v2.BigtableGrpc.BigtableImplBase;

--- a/generated/java/grpc-google-cloud-bigtable-admin-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-bigtable-admin-v2/build.gradle
@@ -89,8 +89,8 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 
           developers {
             developer {
-              id 'Google Inc'
-              name 'Google Inc'
+              id 'Google LLC'
+              name 'Google LLC'
               email 'googleapis-packages@google.com'
               url 'https://github.com/googleapis/googleapis'
               organization 'Google LLC'

--- a/generated/java/grpc-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-bigtable-v2/build.gradle
@@ -89,8 +89,8 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 
           developers {
             developer {
-              id 'Google Inc'
-              name 'Google Inc'
+              id 'Google LLC'
+              name 'Google LLC'
               email 'googleapis-packages@google.com'
               url 'https://github.com/googleapis/googleapis'
               organization 'Google LLC'

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/build.gradle
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/build.gradle
@@ -90,8 +90,8 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 
           developers {
             developer {
-              id 'Google Inc'
-              name 'Google Inc'
+              id 'Google LLC'
+              name 'Google LLC'
               email 'googleapis-packages@google.com'
               url 'https://github.com/googleapis/googleapis'
               organization 'Google LLC'

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/AppProfileName.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/AppProfileName.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.bigtable.admin.v2;
+
+import com.google.common.base.Preconditions;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import com.google.api.resourcenames.ResourceNameType;
+import java.io.IOException;
+import java.util.Map;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class AppProfileName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/instances/{instance}/appProfiles/{app_profile}");
+
+  private final String project;
+  private final String instance;
+  private final String appProfile;
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getInstance() {
+    return instance;
+  }
+
+  public String getAppProfile() {
+    return appProfile;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private AppProfileName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    instance = Preconditions.checkNotNull(builder.getInstance());
+    appProfile = Preconditions.checkNotNull(builder.getAppProfile());
+  }
+
+  public static AppProfileName of(String project, String instance, String appProfile) {
+    return newBuilder()
+      .setProject(project)
+      .setInstance(instance)
+      .setAppProfile(appProfile)
+      .build();
+  }
+
+  /**
+   * @deprecated Use {@link #of(String, String, String)} instead.
+   */
+  @Deprecated
+  public static AppProfileName create(String project, String instance, String appProfile) {
+    return of(project, instance, appProfile);
+  }
+
+  public static AppProfileName parse(String formattedString) {
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "AppProfileName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("instance"), matchMap.get("app_profile"));
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  @Override
+  public ResourceNameType getType() {
+    return AppProfileNameType.instance();
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("project", project, "instance", instance, "app_profile", appProfile);
+  }
+
+  /** Builder for AppProfileName. */
+  public static class Builder {
+
+    private String project;
+    private String instance;
+    private String appProfile;
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getInstance() {
+      return instance;
+    }
+
+    public String getAppProfile() {
+      return appProfile;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setInstance(String instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    public Builder setAppProfile(String appProfile) {
+      this.appProfile = appProfile;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(AppProfileName appProfileName) {
+      project = appProfileName.project;
+      instance = appProfileName.instance;
+      appProfile = appProfileName.appProfile;
+    }
+
+    public AppProfileName build() {
+      return new AppProfileName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof AppProfileName) {
+      AppProfileName that = (AppProfileName) o;
+      return (this.project.equals(that.project))
+          && (this.instance.equals(that.instance))
+          && (this.appProfile.equals(that.appProfile));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= project.hashCode();
+    h *= 1000003;
+    h ^= instance.hashCode();
+    h *= 1000003;
+    h ^= appProfile.hashCode();
+    return h;
+  }
+}
+

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/AppProfileNameType.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/AppProfileNameType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.bigtable.admin.v2;
+
+import com.google.api.resourcenames.ResourceNameType;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class AppProfileNameType implements ResourceNameType {
+
+  private static AppProfileNameType instance = new AppProfileNameType();
+
+  private AppProfileNameType() {}
+
+  public static AppProfileNameType instance() {
+    return instance;
+  }
+}

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CheckConsistencyRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CheckConsistencyRequest.java
@@ -688,9 +688,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithTableName(com.google.bigtable.admin.v2.TableName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.TableName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.CheckConsistencyRequest)
   }
 
+  public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.TableName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.CheckConsistencyRequest)
   private static final com.google.bigtable.admin.v2.CheckConsistencyRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CreateAppProfileRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CreateAppProfileRequest.java
@@ -1016,9 +1016,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setParentWithInstanceName(com.google.bigtable.admin.v2.InstanceName value) {
+      if (value == null) {
+        return setParent("");
+      }
+      return setParent(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+      java.lang.String str = getParent();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.InstanceName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.CreateAppProfileRequest)
   }
 
+  public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+    java.lang.String str = getParent();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.InstanceName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.CreateAppProfileRequest)
   private static final com.google.bigtable.admin.v2.CreateAppProfileRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CreateTableFromSnapshotRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/CreateTableFromSnapshotRequest.java
@@ -864,9 +864,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setParentWithInstanceName(com.google.bigtable.admin.v2.InstanceName value) {
+      if (value == null) {
+        return setParent("");
+      }
+      return setParent(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+      java.lang.String str = getParent();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.InstanceName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.CreateTableFromSnapshotRequest)
   }
 
+  public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+    java.lang.String str = getParent();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.InstanceName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.CreateTableFromSnapshotRequest)
   private static final com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/DeleteAppProfileRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/DeleteAppProfileRequest.java
@@ -599,9 +599,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithAppProfileName(com.google.bigtable.admin.v2.AppProfileName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.AppProfileName getNameAsAppProfileName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.AppProfileName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.DeleteAppProfileRequest)
   }
 
+  public final com.google.bigtable.admin.v2.AppProfileName getNameAsAppProfileName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.AppProfileName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.DeleteAppProfileRequest)
   private static final com.google.bigtable.admin.v2.DeleteAppProfileRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/DeleteSnapshotRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/DeleteSnapshotRequest.java
@@ -533,9 +533,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithSnapshotName(com.google.bigtable.admin.v2.SnapshotName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.SnapshotName getNameAsSnapshotName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.SnapshotName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.DeleteSnapshotRequest)
   }
 
+  public final com.google.bigtable.admin.v2.SnapshotName getNameAsSnapshotName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.SnapshotName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.DeleteSnapshotRequest)
   private static final com.google.bigtable.admin.v2.DeleteSnapshotRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GenerateConsistencyTokenRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GenerateConsistencyTokenRequest.java
@@ -533,9 +533,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithTableName(com.google.bigtable.admin.v2.TableName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.TableName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.GenerateConsistencyTokenRequest)
   }
 
+  public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.TableName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.GenerateConsistencyTokenRequest)
   private static final com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GetAppProfileRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GetAppProfileRequest.java
@@ -524,9 +524,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithAppProfileName(com.google.bigtable.admin.v2.AppProfileName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.AppProfileName getNameAsAppProfileName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.AppProfileName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.GetAppProfileRequest)
   }
 
+  public final com.google.bigtable.admin.v2.AppProfileName getNameAsAppProfileName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.AppProfileName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.GetAppProfileRequest)
   private static final com.google.bigtable.admin.v2.GetAppProfileRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GetSnapshotRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/GetSnapshotRequest.java
@@ -533,9 +533,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithSnapshotName(com.google.bigtable.admin.v2.SnapshotName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.SnapshotName getNameAsSnapshotName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.SnapshotName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.GetSnapshotRequest)
   }
 
+  public final com.google.bigtable.admin.v2.SnapshotName getNameAsSnapshotName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.SnapshotName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.GetSnapshotRequest)
   private static final com.google.bigtable.admin.v2.GetSnapshotRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/ListAppProfilesRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/ListAppProfilesRequest.java
@@ -686,9 +686,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setParentWithInstanceName(com.google.bigtable.admin.v2.InstanceName value) {
+      if (value == null) {
+        return setParent("");
+      }
+      return setParent(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+      java.lang.String str = getParent();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.InstanceName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.ListAppProfilesRequest)
   }
 
+  public final com.google.bigtable.admin.v2.InstanceName getParentAsInstanceName() {
+    java.lang.String str = getParent();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.InstanceName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.ListAppProfilesRequest)
   private static final com.google.bigtable.admin.v2.ListAppProfilesRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/ListSnapshotsRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/ListSnapshotsRequest.java
@@ -776,9 +776,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setParentWithClusterName(com.google.bigtable.admin.v2.ClusterName value) {
+      if (value == null) {
+        return setParent("");
+      }
+      return setParent(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.ClusterName getParentAsClusterName() {
+      java.lang.String str = getParent();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.ClusterName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.ListSnapshotsRequest)
   }
 
+  public final com.google.bigtable.admin.v2.ClusterName getParentAsClusterName() {
+    java.lang.String str = getParent();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.ClusterName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.ListSnapshotsRequest)
   private static final com.google.bigtable.admin.v2.ListSnapshotsRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotName.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotName.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.bigtable.admin.v2;
+
+import com.google.common.base.Preconditions;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import com.google.api.resourcenames.ResourceNameType;
+import java.io.IOException;
+import java.util.Map;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class SnapshotName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}");
+
+  private final String project;
+  private final String instance;
+  private final String cluster;
+  private final String snapshot;
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getInstance() {
+    return instance;
+  }
+
+  public String getCluster() {
+    return cluster;
+  }
+
+  public String getSnapshot() {
+    return snapshot;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private SnapshotName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    instance = Preconditions.checkNotNull(builder.getInstance());
+    cluster = Preconditions.checkNotNull(builder.getCluster());
+    snapshot = Preconditions.checkNotNull(builder.getSnapshot());
+  }
+
+  public static SnapshotName of(String project, String instance, String cluster, String snapshot) {
+    return newBuilder()
+      .setProject(project)
+      .setInstance(instance)
+      .setCluster(cluster)
+      .setSnapshot(snapshot)
+      .build();
+  }
+
+  /**
+   * @deprecated Use {@link #of(String, String, String, String)} instead.
+   */
+  @Deprecated
+  public static SnapshotName create(String project, String instance, String cluster, String snapshot) {
+    return of(project, instance, cluster, snapshot);
+  }
+
+  public static SnapshotName parse(String formattedString) {
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "SnapshotName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("instance"), matchMap.get("cluster"), matchMap.get("snapshot"));
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  @Override
+  public ResourceNameType getType() {
+    return SnapshotNameType.instance();
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("project", project, "instance", instance, "cluster", cluster, "snapshot", snapshot);
+  }
+
+  /** Builder for SnapshotName. */
+  public static class Builder {
+
+    private String project;
+    private String instance;
+    private String cluster;
+    private String snapshot;
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getInstance() {
+      return instance;
+    }
+
+    public String getCluster() {
+      return cluster;
+    }
+
+    public String getSnapshot() {
+      return snapshot;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setInstance(String instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    public Builder setCluster(String cluster) {
+      this.cluster = cluster;
+      return this;
+    }
+
+    public Builder setSnapshot(String snapshot) {
+      this.snapshot = snapshot;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(SnapshotName snapshotName) {
+      project = snapshotName.project;
+      instance = snapshotName.instance;
+      cluster = snapshotName.cluster;
+      snapshot = snapshotName.snapshot;
+    }
+
+    public SnapshotName build() {
+      return new SnapshotName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof SnapshotName) {
+      SnapshotName that = (SnapshotName) o;
+      return (this.project.equals(that.project))
+          && (this.instance.equals(that.instance))
+          && (this.cluster.equals(that.cluster))
+          && (this.snapshot.equals(that.snapshot));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= project.hashCode();
+    h *= 1000003;
+    h ^= instance.hashCode();
+    h *= 1000003;
+    h ^= cluster.hashCode();
+    h *= 1000003;
+    h ^= snapshot.hashCode();
+    return h;
+  }
+}
+

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotNameType.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotNameType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.bigtable.admin.v2;
+
+import com.google.api.resourcenames.ResourceNameType;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class SnapshotNameType implements ResourceNameType {
+
+  private static SnapshotNameType instance = new SnapshotNameType();
+
+  private SnapshotNameType() {}
+
+  public static SnapshotNameType instance() {
+    return instance;
+  }
+}

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotTableRequest.java
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/SnapshotTableRequest.java
@@ -1298,9 +1298,30 @@ private static final long serialVersionUID = 0L;
     }
 
 
+    public final Builder setNameWithTableName(com.google.bigtable.admin.v2.TableName value) {
+      if (value == null) {
+        return setName("");
+      }
+      return setName(value.toString());
+    }
+    
+    public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+      java.lang.String str = getName();
+      if (str.isEmpty()) {
+        return null;
+      }
+      return com.google.bigtable.admin.v2.TableName.parse(str);
+    }
     // @@protoc_insertion_point(builder_scope:google.bigtable.admin.v2.SnapshotTableRequest)
   }
 
+  public final com.google.bigtable.admin.v2.TableName getNameAsTableName() {
+    java.lang.String str = getName();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return com.google.bigtable.admin.v2.TableName.parse(str);
+  }
   // @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.SnapshotTableRequest)
   private static final com.google.bigtable.admin.v2.SnapshotTableRequest DEFAULT_INSTANCE;
   static {

--- a/generated/java/proto-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/proto-google-cloud-bigtable-v2/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   compile "com.google.protobuf:protobuf-java:3.4.0"
   compile "com.google.api:api-common:1.1.0"
   compile project(":proto-google-common-protos")
-  compile project(":proto-google-iam-v1")
 }
 
 ext {
@@ -90,8 +89,8 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 
           developers {
             developer {
-              id 'Google Inc'
-              name 'Google Inc'
+              id 'Google LLC'
+              name 'Google LLC'
               email 'googleapis-packages@google.com'
               url 'https://github.com/googleapis/googleapis'
               organization 'Google LLC'


### PR DESCRIPTION
- add AppProfiles
- add Snapshots
- add instance level iam
- Move Bigtable client to subpackage & rename to BaseBigtableData

This was generated using artman 0.5.5 with toolkit 9d772518c7b0347e258fbc468f390a02014893da (before the license change)