### PR TITLE
Run node CI as non-root user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
             # Needed to find the right packages when installed from the top.
             ./runtests.sh
-    working_directory: /var/code/googleapis/
+    working_directory: /home/node/code/googleapis/
 
   node6:
     docker:
@@ -63,7 +63,7 @@ jobs:
 
             # Needed to find the right packages when installed from the top.
             ./runtests.sh
-    working_directory: /var/code/googleapis/
+    working_directory: /home/node/code/googleapis/
 
   node7:
     docker:
@@ -83,7 +83,7 @@ jobs:
 
             # Needed to find the right packages when installed from the top.
             ./runtests.sh
-    working_directory: /var/code/googleapis/
+    working_directory: /home/node/code/googleapis/
 
   node8:
     docker:
@@ -102,7 +102,7 @@ jobs:
             cd generated/nodejs/
             # Needed to find the right packages when installed from the top.
             ./runtests.sh
-    working_directory: /var/code/googleapis/
+    working_directory: /home/node/code/googleapis/
 
   openjdk7:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
   node4:
     docker:
       - image: node:4
+        user: node
     steps:
       - checkout
       - run:
@@ -47,6 +48,7 @@ jobs:
   node6:
     docker:
       - image: node:6
+        user: node
     steps:
       - checkout
       - run:
@@ -66,6 +68,7 @@ jobs:
   node7:
     docker:
       - image: node:7
+        user: node
     steps:
       - checkout
       - run:
@@ -85,6 +88,7 @@ jobs:
   node8:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CircleCI docker containers have problems unpacking GRPC pre-built binary for Node.js if run as root. That's reported as a separate issue. For now, let's run Node.js tests as non-root user which will save literally tens of minutes for each CI run.