### PR TITLE
Fixing Java builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - run:
           name: Run GAPIC unit tests in OpenJDK 7.
-          command: ./generated/java/gradlew -p ./generated/java clean test
+          command: ./generated/java/gradlew -p ./generated/java clean test -Dorg.gradle.jvmargs=-Xmx256m
     working_directory: /var/code/googleapis/
 
   openjdk8:
@@ -125,7 +125,7 @@ jobs:
       - checkout
       - run:
           name: Run GAPIC unit tests in OpenJDK 8.
-          command: ./generated/java/gradlew -p ./generated/java clean test
+          command: ./generated/java/gradlew -p ./generated/java clean test -Dorg.gradle.jvmargs=-Xmx256m
     working_directory: /var/code/googleapis/
 
   python27:


### PR DESCRIPTION
Java tests have been failing with exit code 137; after some research, it looks like the problem is memory usage. This change limits memory usage of gradle when running tests. I have verified by ssh into Circle that the tests pass now on both openjdk7 & openjdk8. 
