### PR TITLE
Bump versions for dlpv2 too

### DIFF
--- a/generated/java/grpc-google-cloud-dlp-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-dlp-v2/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'signing'
 
 description = 'GRPC library for grpc-google-cloud-dlp-v2'
 group = "com.google.api.grpc"
-version = "0.2.0"
+version = "0.3.0"
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/generated/java/proto-google-cloud-dlp-v2/build.gradle
+++ b/generated/java/proto-google-cloud-dlp-v2/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'signing'
 
 description = 'PROTO library for proto-google-cloud-dlp-v2'
 group = "com.google.api.grpc"
-version = "0.2.0"
+version = "0.3.0"
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 


### PR DESCRIPTION
Grpc/proto package version for dlpv2 didn't get updated along with all the other APIs in the past commit.