### PR TITLE
Set encoding to UTF-8 for javadoc (otherwise `javadoc` bulid target fails)

### DIFF
--- a/generated/java/gapic-google-cloud-bigquerydatatransfer-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-bigquerydatatransfer-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-bigtable-admin-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-bigtable-admin-v2/build.gradle
@@ -35,3 +35,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-bigtable-v2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-container-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-container-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-dataproc-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-dataproc-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-datastore-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-datastore-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-dialogflow-v2beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-dialogflow-v2beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-dlp-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-dlp-v2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-dlp-v2beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-dlp-v2beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-dlp-v2beta2/build.gradle
+++ b/generated/java/gapic-google-cloud-dlp-v2beta2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-error-reporting-v1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-error-reporting-v1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-firestore-v1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-firestore-v1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-language-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-language-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-language-v1beta2/build.gradle
+++ b/generated/java/gapic-google-cloud-language-v1beta2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-logging-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-logging-v2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-monitoring-v3/build.gradle
+++ b/generated/java/gapic-google-cloud-monitoring-v3/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-os-login-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-os-login-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-pubsub-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-pubsub-v1/build.gradle
@@ -35,3 +35,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-spanner-admin-database-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-spanner-admin-database-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-spanner-admin-instance-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-spanner-admin-instance-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-spanner-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-spanner-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-speech-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-speech-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-speech-v1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-speech-v1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-speech-v1p1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-speech-v1p1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-texttospeech-v1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-texttospeech-v1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-trace-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-trace-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-trace-v2/build.gradle
+++ b/generated/java/gapic-google-cloud-trace-v2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-video-intelligence-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-video-intelligence-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-video-intelligence-v1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-video-intelligence-v1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-video-intelligence-v1beta2/build.gradle
+++ b/generated/java/gapic-google-cloud-video-intelligence-v1beta2/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-video-intelligence-v1p1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-video-intelligence-v1p1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-vision-v1/build.gradle
+++ b/generated/java/gapic-google-cloud-vision-v1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-vision-v1p1beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-vision-v1p1beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-cloud-vision-v1p2beta1/build.gradle
+++ b/generated/java/gapic-google-cloud-vision-v1p2beta1/build.gradle
@@ -34,3 +34,4 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/gapic-google-longrunning-v1/build.gradle
+++ b/generated/java/gapic-google-longrunning-v1/build.gradle
@@ -34,3 +34,5 @@ sourceSets {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-appengine-v1/build.gradle
+++ b/generated/java/grpc-google-appengine-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-bigquerydatatransfer-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-bigquerydatatransfer-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-bigtable-admin-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-bigtable-admin-v2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-bigtable-v2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-container-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-container-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-dataproc-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-dataproc-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-datastore-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-datastore-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-dialogflow-v2beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-dialogflow-v2beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-dlp-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-dlp-v2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-dlp-v2beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-dlp-v2beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-dlp-v2beta2/build.gradle
+++ b/generated/java/grpc-google-cloud-dlp-v2beta2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-error-reporting-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-error-reporting-v1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-firestore-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-firestore-v1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-language-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-language-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-language-v1beta2/build.gradle
+++ b/generated/java/grpc-google-cloud-language-v1beta2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-logging-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-logging-v2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-monitoring-v3/build.gradle
+++ b/generated/java/grpc-google-cloud-monitoring-v3/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-os-login-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-os-login-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-pubsub-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-pubsub-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-spanner-admin-database-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-admin-database-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-spanner-admin-instance-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-admin-instance-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-spanner-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-spanner-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-speech-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-speech-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-speech-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-speech-v1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-speech-v1p1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-speech-v1p1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-texttospeech-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-texttospeech-v1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-trace-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-trace-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-trace-v2/build.gradle
+++ b/generated/java/grpc-google-cloud-trace-v2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-video-intelligence-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-video-intelligence-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-video-intelligence-v1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-video-intelligence-v1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-video-intelligence-v1beta2/build.gradle
+++ b/generated/java/grpc-google-cloud-video-intelligence-v1beta2/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-video-intelligence-v1p1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-video-intelligence-v1p1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-vision-v1/build.gradle
+++ b/generated/java/grpc-google-cloud-vision-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-vision-v1p1beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-vision-v1p1beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-cloud-vision-v1p2beta1/build.gradle
+++ b/generated/java/grpc-google-cloud-vision-v1p2beta1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-common-protos/build.gradle
+++ b/generated/java/grpc-google-common-protos/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/grpc-google-iam-v1/build.gradle
+++ b/generated/java/grpc-google-iam-v1/build.gradle
@@ -46,3 +46,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-appengine-v1/build.gradle
+++ b/generated/java/proto-google-appengine-v1/build.gradle
@@ -50,3 +50,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-bigquerydatatransfer-v1/build.gradle
+++ b/generated/java/proto-google-cloud-bigquerydatatransfer-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-bigtable-admin-v2/build.gradle
+++ b/generated/java/proto-google-cloud-bigtable-admin-v2/build.gradle
@@ -50,3 +50,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-bigtable-v2/build.gradle
+++ b/generated/java/proto-google-cloud-bigtable-v2/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-container-v1/build.gradle
+++ b/generated/java/proto-google-cloud-container-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-dataproc-v1/build.gradle
+++ b/generated/java/proto-google-cloud-dataproc-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-datastore-v1/build.gradle
+++ b/generated/java/proto-google-cloud-datastore-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-dialogflow-v2beta1/build.gradle
+++ b/generated/java/proto-google-cloud-dialogflow-v2beta1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-dlp-v2/build.gradle
+++ b/generated/java/proto-google-cloud-dlp-v2/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-dlp-v2beta1/build.gradle
+++ b/generated/java/proto-google-cloud-dlp-v2beta1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-dlp-v2beta2/build.gradle
+++ b/generated/java/proto-google-cloud-dlp-v2beta2/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-error-reporting-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-error-reporting-v1beta1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-firestore-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-firestore-v1beta1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-language-v1/build.gradle
+++ b/generated/java/proto-google-cloud-language-v1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-language-v1beta2/build.gradle
+++ b/generated/java/proto-google-cloud-language-v1beta2/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-logging-v2/build.gradle
+++ b/generated/java/proto-google-cloud-logging-v2/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-monitoring-v3/build.gradle
+++ b/generated/java/proto-google-cloud-monitoring-v3/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-os-login-v1/build.gradle
+++ b/generated/java/proto-google-cloud-os-login-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-pubsub-v1/build.gradle
+++ b/generated/java/proto-google-cloud-pubsub-v1/build.gradle
@@ -50,3 +50,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-spanner-admin-database-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-admin-database-v1/build.gradle
@@ -50,3 +50,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-spanner-admin-instance-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-admin-instance-v1/build.gradle
@@ -50,3 +50,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-spanner-v1/build.gradle
+++ b/generated/java/proto-google-cloud-spanner-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-speech-v1/build.gradle
+++ b/generated/java/proto-google-cloud-speech-v1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-speech-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-speech-v1beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-speech-v1p1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-speech-v1p1beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-texttospeech-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-texttospeech-v1beta1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-trace-v1/build.gradle
+++ b/generated/java/proto-google-cloud-trace-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-trace-v2/build.gradle
+++ b/generated/java/proto-google-cloud-trace-v2/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-video-intelligence-v1/build.gradle
+++ b/generated/java/proto-google-cloud-video-intelligence-v1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-video-intelligence-v1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-video-intelligence-v1beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-video-intelligence-v1beta2/build.gradle
+++ b/generated/java/proto-google-cloud-video-intelligence-v1beta2/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-video-intelligence-v1p1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-video-intelligence-v1p1beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-vision-v1/build.gradle
+++ b/generated/java/proto-google-cloud-vision-v1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-vision-v1p1beta1/build.gradle
+++ b/generated/java/proto-google-cloud-vision-v1p1beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-cloud-vision-v1p2beta1/build.gradle
+++ b/generated/java/proto-google-cloud-vision-v1p2beta1/build.gradle
@@ -48,3 +48,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-common-protos/build.gradle
+++ b/generated/java/proto-google-common-protos/build.gradle
@@ -47,3 +47,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"

--- a/generated/java/proto-google-iam-v1/build.gradle
+++ b/generated/java/proto-google-iam-v1/build.gradle
@@ -49,3 +49,4 @@ artifacts {
 }
 
 compileJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"


### PR DESCRIPTION
This should also be added to generator snippets (will do later).