### PR TITLE
add compatibility check badge to README

### DIFF
--- a/generated/python/grpc-google-iam-v1/README.rst
+++ b/generated/python/grpc-google-iam-v1/README.rst
@@ -1,5 +1,9 @@
+|compat_check_pypi|
+
 gRPC library for google-iam-v1
 
 grpc-google-iam-v1 is the IDL-derived library for the google-iam (v1) service in the googleapis_ repository.
 
+.. |compat_check_pypi| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=grpc-google-iam-v1
+   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=grpc-google-iam-v1
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/iam/v1


### PR DESCRIPTION
Hello google package maintainer,
The badge being added to the README in this PR will indicate your compatibility with other google packages. This addresses a set of user bugs which have happened when a user depends on two Cloud libraries (or runtimes that bundle libraries), say A and B, which both depend on library C. If the two libraries require different versions of C, the users can run into issues both when they pip install the libraries, and when they deploy their code. Our compatibility server checks that all libraries we make including this one are self and pairwise compatible as well as not having any deprecated dependencies. The badge will mark the build for your project green when the latest version available on PyPI meets all compatibility checks with itself and all other libraries. The badge target will link to a details page that elaborates on the current status. This should help you fix issues pre-release, to avoid user surprises. For more information, please take a look at our project charter at go/python-cloud-dependencies-project-charter and the badging PRD https://docs.google.com/document/d/1GYRFrfUou2ssY71AtnLkc8Sg1SD4dxqN4GzlatGHHyI/edit?ts=5c6f031d